### PR TITLE
fix: smart durations toggle layout on settings page

### DIFF
--- a/templates/pages/dashboard_settings.html
+++ b/templates/pages/dashboard_settings.html
@@ -20,20 +20,21 @@
             <div class="form-group">
                 <label class="form-label" for="name">Name</label>
                 <input type="text" id="name" name="name" class="form-input" required value="{{.Host.Name}}">
-                <div style="margin-top: 0.75rem;">
-                    <label class="toggle-container">
-                        <input type="checkbox" name="smart_durations" class="toggle-input" {{if .Host.SmartDurations}}checked{{end}}>
-                        <span class="toggle-switch"></span>
-                        <span class="toggle-label">Smart durations</span>
-                    </label>
-                    <p class="form-hint">End meetings 5-10 minutes early to give you buffer time</p>
-                </div>
             </div>
             <div class="form-group">
                 <label class="form-label" for="slug">Booking URL</label>
                 <input type="text" id="slug" name="slug" class="form-input" required pattern="[a-z0-9-]+" value="{{.Host.Slug}}">
                 <p class="form-hint">Your booking page: {{$.BaseURL}}/m/{{.Tenant.Slug}}/{{.Host.Slug}}</p>
             </div>
+        </div>
+
+        <div class="form-group">
+            <label class="toggle-container">
+                <input type="checkbox" name="smart_durations" class="toggle-input" {{if .Host.SmartDurations}}checked{{end}}>
+                <span class="toggle-switch"></span>
+                <span class="toggle-label">Smart durations</span>
+            </label>
+            <p class="form-hint">End meetings 5-10 minutes early to give you buffer time</p>
         </div>
 
         <div class="section-actions">


### PR DESCRIPTION
## Summary
- Move smart durations toggle to its own row below the Name/Booking URL fields
- Toggle now sits at full width beneath the form row, with label and hint properly aligned

## Test plan
- [x] All tests pass
- [ ] CI validation
- [ ] Visual check: toggle appears as its own row below Name and Booking URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)