### PR TITLE
fix: smart durations toggle uses correct CSS classes

### DIFF
--- a/templates/pages/dashboard_settings.html
+++ b/templates/pages/dashboard_settings.html
@@ -28,13 +28,15 @@
             </div>
         </div>
 
-        <div class="form-group">
-            <label class="toggle-container">
-                <input type="checkbox" name="smart_durations" class="toggle-input" {{if .Host.SmartDurations}}checked{{end}}>
-                <span class="toggle-switch"></span>
-                <span class="toggle-label">Smart durations</span>
+        <div class="toggle-row" style="border: none; padding-top: 0;">
+            <div class="toggle-info">
+                <h4>Smart durations</h4>
+                <p>End meetings 5-10 minutes early to give you buffer time</p>
+            </div>
+            <label class="toggle-switch">
+                <input type="checkbox" name="smart_durations" {{if .Host.SmartDurations}}checked{{end}}>
+                <span class="toggle-slider"></span>
             </label>
-            <p class="form-hint">End meetings 5-10 minutes early to give you buffer time</p>
         </div>
 
         <div class="section-actions">


### PR DESCRIPTION
## Summary
- Replace non-existent `toggle-container`/`toggle-input`/`toggle-label` classes with the proper `toggle-row` + `toggle-info` + `toggle-switch`/`toggle-slider` pattern used throughout the app
- Toggle now renders as: label+description on left, switch on right — consistent with template form toggles

## Test plan
- [x] All tests pass
- [ ] CI validation
- [ ] Visual check: toggle row with label left, switch right

🤖 Generated with [Claude Code](https://claude.com/claude-code)