### PR TITLE
Fix reschedule before confirmation using original time (#23)

### DIFF
--- a/internal/repository/booking_test.go
+++ b/internal/repository/booking_test.go
@@ -1,0 +1,95 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+func TestBookingRepository_Update_PersistsTimeFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+	}{
+		{
+			name:   "PostgreSQL",
+			driver: "postgres",
+		},
+		{
+			name:   "SQLite",
+			driver: "sqlite",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.driver == "postgres" && !isPostgresAvailable() {
+				t.Skip("PostgreSQL not available")
+			}
+
+			db, cleanup := setupTestDB(t, tt.driver)
+			defer cleanup()
+
+			repo := &BookingRepository{db: db, driver: tt.driver}
+
+			// Create a booking with initial times
+			_, _, booking := createTestBooking(t, db, tt.driver)
+
+			originalStart := booking.StartTime
+			originalEnd := booking.EndTime
+			originalDuration := booking.Duration
+
+			// Simulate rescheduling: update time fields
+			newStart := time.Now().UTC().Add(48 * time.Hour).Truncate(time.Second)
+			newEnd := newStart.Add(30 * time.Minute)
+			newDuration := 30
+
+			booking.StartTime = models.NewSQLiteTime(newStart)
+			booking.EndTime = models.NewSQLiteTime(newEnd)
+			booking.Duration = newDuration
+			booking.UpdatedAt = models.Now()
+			booking.Status = models.BookingStatusPending
+
+			err := repo.Update(context.Background(), booking)
+			if err != nil {
+				t.Fatalf("Update failed: %v", err)
+			}
+
+			// Re-read booking from DB
+			updated, err := repo.GetByID(context.Background(), booking.ID)
+			if err != nil {
+				t.Fatalf("GetByID failed: %v", err)
+			}
+			if updated == nil {
+				t.Fatal("expected booking, got nil")
+			}
+
+			// Verify the new times were persisted (not the originals)
+			if updated.StartTime.UTC().Equal(originalStart.UTC()) {
+				t.Error("start_time was NOT updated — still matches original time")
+			}
+			if updated.EndTime.UTC().Equal(originalEnd.UTC()) {
+				t.Error("end_time was NOT updated — still matches original time")
+			}
+			if updated.Duration == originalDuration {
+				t.Errorf("duration was NOT updated — still %d", originalDuration)
+			}
+
+			// Verify the new times match what we set
+			if !updated.StartTime.UTC().Truncate(time.Second).Equal(newStart) {
+				t.Errorf("expected start_time %v, got %v", newStart, updated.StartTime.UTC().Truncate(time.Second))
+			}
+			if !updated.EndTime.UTC().Truncate(time.Second).Equal(newEnd) {
+				t.Errorf("expected end_time %v, got %v", newEnd, updated.EndTime.UTC().Truncate(time.Second))
+			}
+			if updated.Duration != newDuration {
+				t.Errorf("expected duration %d, got %d", newDuration, updated.Duration)
+			}
+			if updated.Status != models.BookingStatusPending {
+				t.Errorf("expected status %s, got %s", models.BookingStatusPending, updated.Status)
+			}
+		})
+	}
+}

--- a/internal/repository/booking_test.go
+++ b/internal/repository/booking_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/meet-when/meet-when/internal/models"
 )
 
@@ -32,14 +33,74 @@ func TestBookingRepository_Update_PersistsTimeFields(t *testing.T) {
 			db, cleanup := setupTestDB(t, tt.driver)
 			defer cleanup()
 
-			repo := &BookingRepository{db: db, driver: tt.driver}
+			repos := NewRepositories(db, tt.driver)
 
-			// Create a booking with initial times
-			_, _, booking := createTestBooking(t, db, tt.driver)
+			ctx := context.Background()
+			suffix := uuid.New().String()[:8]
 
-			originalStart := booking.StartTime
-			originalEnd := booking.EndTime
-			originalDuration := booking.Duration
+			// Create tenant
+			tenant := &models.Tenant{
+				ID:        uuid.New().String(),
+				Slug:      "test-tenant-" + suffix,
+				Name:      "Test Tenant",
+				CreatedAt: models.Now(),
+				UpdatedAt: models.Now(),
+			}
+			if err := repos.Tenant.Create(ctx, tenant); err != nil {
+				t.Fatalf("failed to create tenant: %v", err)
+			}
+
+			// Create host
+			host := &models.Host{
+				ID:           uuid.New().String(),
+				TenantID:     tenant.ID,
+				Email:        "host-" + suffix + "@example.com",
+				PasswordHash: "hash",
+				Name:         "Test Host",
+				Slug:         "host-" + suffix,
+				Timezone:     "UTC",
+				CreatedAt:    models.Now(),
+				UpdatedAt:    models.Now(),
+			}
+			if err := repos.Host.Create(ctx, host); err != nil {
+				t.Fatalf("failed to create host: %v", err)
+			}
+
+			// Create template
+			tmpl := &models.MeetingTemplate{
+				ID:        uuid.New().String(),
+				HostID:    host.ID,
+				Slug:      "test-template-" + suffix,
+				Name:      "Test Template",
+				CreatedAt: models.Now(),
+				UpdatedAt: models.Now(),
+			}
+			if err := repos.Template.Create(ctx, tmpl); err != nil {
+				t.Fatalf("failed to create template: %v", err)
+			}
+
+			// Create booking with initial times
+			originalStart := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
+			originalEnd := originalStart.Add(60 * time.Minute)
+			originalDuration := 60
+
+			booking := &models.Booking{
+				ID:           uuid.New().String(),
+				TemplateID:   tmpl.ID,
+				HostID:       host.ID,
+				Token:        "test-token-" + suffix,
+				Status:       models.BookingStatusPending,
+				StartTime:    models.NewSQLiteTime(originalStart),
+				EndTime:      models.NewSQLiteTime(originalEnd),
+				Duration:     originalDuration,
+				InviteeName:  "Invitee",
+				InviteeEmail: "invitee@example.com",
+				CreatedAt:    models.Now(),
+				UpdatedAt:    models.Now(),
+			}
+			if err := repos.Booking.Create(ctx, booking); err != nil {
+				t.Fatalf("failed to create booking: %v", err)
+			}
 
 			// Simulate rescheduling: update time fields
 			newStart := time.Now().UTC().Add(48 * time.Hour).Truncate(time.Second)
@@ -50,15 +111,14 @@ func TestBookingRepository_Update_PersistsTimeFields(t *testing.T) {
 			booking.EndTime = models.NewSQLiteTime(newEnd)
 			booking.Duration = newDuration
 			booking.UpdatedAt = models.Now()
-			booking.Status = models.BookingStatusPending
 
-			err := repo.Update(context.Background(), booking)
+			err := repos.Booking.Update(ctx, booking)
 			if err != nil {
 				t.Fatalf("Update failed: %v", err)
 			}
 
 			// Re-read booking from DB
-			updated, err := repo.GetByID(context.Background(), booking.ID)
+			updated, err := repos.Booking.GetByID(ctx, booking.ID)
 			if err != nil {
 				t.Fatalf("GetByID failed: %v", err)
 			}
@@ -67,10 +127,10 @@ func TestBookingRepository_Update_PersistsTimeFields(t *testing.T) {
 			}
 
 			// Verify the new times were persisted (not the originals)
-			if updated.StartTime.UTC().Equal(originalStart.UTC()) {
+			if updated.StartTime.UTC().Truncate(time.Second).Equal(originalStart) {
 				t.Error("start_time was NOT updated — still matches original time")
 			}
-			if updated.EndTime.UTC().Equal(originalEnd.UTC()) {
+			if updated.EndTime.UTC().Truncate(time.Second).Equal(originalEnd) {
 				t.Error("end_time was NOT updated — still matches original time")
 			}
 			if updated.Duration == originalDuration {

--- a/internal/repository/booking_test.go
+++ b/internal/repository/booking_test.go
@@ -66,16 +66,13 @@ func TestBookingRepository_Update_PersistsTimeFields(t *testing.T) {
 				t.Fatalf("failed to create host: %v", err)
 			}
 
-			// Create template
-			tmpl := &models.MeetingTemplate{
-				ID:        uuid.New().String(),
-				HostID:    host.ID,
-				Slug:      "test-template-" + suffix,
-				Name:      "Test Template",
-				CreatedAt: models.Now(),
-				UpdatedAt: models.Now(),
-			}
-			if err := repos.Template.Create(ctx, tmpl); err != nil {
+			// Create template (use raw SQL to set calendar_id to NULL, avoiding FK constraint)
+			templateID := uuid.New().String()
+			_, err := db.Exec(`
+				INSERT INTO meeting_templates (id, host_id, slug, name, durations, location_type, calendar_id, is_active, is_private, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, NULL, 1, 0, ?, ?)
+			`, templateID, host.ID, "test-template-"+suffix, "Test Template", `[30]`, "google_meet", models.Now(), models.Now())
+			if err != nil {
 				t.Fatalf("failed to create template: %v", err)
 			}
 
@@ -86,7 +83,7 @@ func TestBookingRepository_Update_PersistsTimeFields(t *testing.T) {
 
 			booking := &models.Booking{
 				ID:           uuid.New().String(),
-				TemplateID:   tmpl.ID,
+				TemplateID:   templateID,
 				HostID:       host.ID,
 				Token:        "test-token-" + suffix,
 				Status:       models.BookingStatusPending,
@@ -112,7 +109,7 @@ func TestBookingRepository_Update_PersistsTimeFields(t *testing.T) {
 			booking.Duration = newDuration
 			booking.UpdatedAt = models.Now()
 
-			err := repos.Booking.Update(ctx, booking)
+			err = repos.Booking.Update(ctx, booking)
 			if err != nil {
 				t.Fatalf("Update failed: %v", err)
 			}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -914,13 +914,15 @@ func (r *BookingRepository) Update(ctx context.Context, booking *models.Booking)
 	query := q(r.driver, `
 		UPDATE bookings
 		SET status = $1, conference_link = $2, calendar_event_id = $3,
-		    cancelled_by = $4, cancel_reason = $5, reminder_sent = $6, is_archived = $7
-		WHERE id = $8
+		    cancelled_by = $4, cancel_reason = $5, reminder_sent = $6, is_archived = $7,
+		    start_time = $8, end_time = $9, duration = $10, updated_at = $11
+		WHERE id = $12
 	`)
 	_, err := r.db.ExecContext(ctx, query,
 		booking.Status, booking.ConferenceLink, booking.CalendarEventID,
 		booking.CancelledBy, booking.CancelReason, booking.ReminderSent,
-		booking.IsArchived, booking.ID)
+		booking.IsArchived, booking.StartTime, booking.EndTime, booking.Duration,
+		booking.UpdatedAt, booking.ID)
 	return err
 }
 


### PR DESCRIPTION
`BookingRepository.Update()` was not persisting `start_time`, `end_time`,
`duration`, or `updated_at` columns. When a user rescheduled a pending
booking, the new times were updated in memory but never written to the
database. On host confirmation, the booking was re-read from the DB
with the original times, causing calendar events and notifications to
use the pre-reschedule schedule.

https://claude.ai/code/session_01NKcE25VZXXMxoa5X9bHPEA