### PR TITLE
Fix onboarding page styling and template FK constraint

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -626,9 +626,11 @@ func (r *TemplateRepository) Create(ctx context.Context, tmpl *models.MeetingTem
 			is_active, is_private, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
 	`)
+	// Empty CalendarID must be stored as NULL to satisfy the FK constraint.
+	calendarID := sql.NullString{String: tmpl.CalendarID, Valid: tmpl.CalendarID != ""}
 	_, err := r.db.ExecContext(ctx, query,
 		tmpl.ID, tmpl.HostID, tmpl.Slug, tmpl.Name, tmpl.Description,
-		tmpl.Durations, tmpl.LocationType, tmpl.CustomLocation, tmpl.CalendarID,
+		tmpl.Durations, tmpl.LocationType, tmpl.CustomLocation, calendarID,
 		tmpl.RequiresApproval, tmpl.MinNoticeMinutes, tmpl.MaxScheduleDays,
 		tmpl.PreBufferMinutes, tmpl.PostBufferMinutes, tmpl.AvailabilityRules,
 		tmpl.InviteeQuestions, tmpl.ConfirmationEmail, tmpl.ReminderEmail,
@@ -746,9 +748,10 @@ func (r *TemplateRepository) Update(ctx context.Context, tmpl *models.MeetingTem
 		    confirmation_email = $15, reminder_email = $16, is_active = $17, is_private = $18
 		WHERE id = $19
 	`)
+	calendarID := sql.NullString{String: tmpl.CalendarID, Valid: tmpl.CalendarID != ""}
 	_, err := r.db.ExecContext(ctx, query,
 		tmpl.Slug, tmpl.Name, tmpl.Description, tmpl.Durations, tmpl.LocationType,
-		tmpl.CustomLocation, tmpl.CalendarID, tmpl.RequiresApproval,
+		tmpl.CustomLocation, calendarID, tmpl.RequiresApproval,
 		tmpl.MinNoticeMinutes, tmpl.MaxScheduleDays, tmpl.PreBufferMinutes,
 		tmpl.PostBufferMinutes, tmpl.AvailabilityRules, tmpl.InviteeQuestions,
 		tmpl.ConfirmationEmail, tmpl.ReminderEmail, tmpl.IsActive, tmpl.IsPrivate, tmpl.ID)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -900,6 +900,325 @@ body.landing .section-header {
     max-width: 600px;
 }
 
+/* ============================================
+   Onboarding Wizard
+   ============================================ */
+.onboarding-container {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 48px 24px;
+}
+
+.onboarding-header {
+    text-align: center;
+    margin-bottom: 32px;
+}
+
+.onboarding-header h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 16px 0 4px;
+}
+
+.onboarding-header p {
+    color: var(--gray-500);
+    font-size: 0.9rem;
+}
+
+.onboarding-progress {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    margin-bottom: 32px;
+}
+
+.progress-step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+}
+
+.progress-step .step-number {
+    width: 36px;
+    height: 36px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    background: var(--gray-200);
+    color: var(--gray-500);
+}
+
+.progress-step.active .step-number {
+    background: var(--accent);
+    color: var(--white);
+}
+
+.progress-step.completed .step-number {
+    background: var(--accent);
+    color: var(--white);
+}
+
+.step-label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--gray-500);
+}
+
+.progress-step.active .step-label {
+    color: var(--black);
+    font-weight: 600;
+}
+
+.progress-line {
+    width: 48px;
+    height: 2px;
+    background: var(--gray-200);
+    margin: 0 8px;
+    margin-bottom: 22px; /* offset for step-label height */
+}
+
+.progress-line.active {
+    background: var(--accent);
+}
+
+.onboarding-content {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: 32px;
+}
+
+.onboarding-step h2 {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin-bottom: 4px;
+}
+
+.onboarding-step .step-description {
+    color: var(--gray-500);
+    font-size: 0.875rem;
+    margin-bottom: 24px;
+}
+
+.onboarding-actions {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 24px;
+    padding-top: 24px;
+    border-top: 1px solid var(--gray-100);
+}
+
+/* Calendar connection options in step 2 */
+.calendar-options {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.calendar-option {
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-md);
+    padding: 20px;
+}
+
+.calendar-option-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.calendar-option-header h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.calendar-option p {
+    color: var(--gray-500);
+    font-size: 0.85rem;
+    margin-bottom: 12px;
+}
+
+.caldav-details {
+    margin-top: 12px;
+}
+
+.caldav-form {
+    margin-top: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.connected-calendars {
+    margin-bottom: 20px;
+    padding: 16px;
+    background: var(--gray-50);
+    border-radius: var(--radius-md);
+}
+
+.connected-calendars h3 {
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.connected-calendars ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.connected-calendars li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.875rem;
+    padding: 4px 0;
+}
+
+/* ============================================
+   Onboarding Complete
+   ============================================ */
+.onboarding-complete-container {
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 48px 24px;
+    text-align: center;
+}
+
+.onboarding-complete-container .success-icon {
+    color: var(--accent);
+    margin-bottom: 16px;
+}
+
+.onboarding-complete-container h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.onboarding-complete-container .subtitle {
+    color: var(--gray-500);
+    font-size: 0.95rem;
+    margin-bottom: 32px;
+}
+
+.booking-link-box {
+    text-align: left;
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: 20px;
+    margin-bottom: 24px;
+}
+
+.link-container {
+    display: flex;
+    gap: 8px;
+}
+
+.link-container .form-input {
+    flex: 1;
+}
+
+.copy-feedback {
+    color: var(--accent);
+    font-size: 0.8rem;
+    margin-top: 8px;
+}
+
+.templates-list {
+    text-align: left;
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: 20px;
+    margin-bottom: 24px;
+}
+
+.templates-list h3 {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.templates-list ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.templates-list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 0;
+    border-top: 1px solid var(--gray-100);
+}
+
+.templates-list li:first-child {
+    border-top: none;
+    padding-top: 0;
+}
+
+.template-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.template-link {
+    font-size: 0.8rem;
+    color: var(--gray-500);
+}
+
+.next-steps {
+    text-align: left;
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: 20px;
+    margin-bottom: 24px;
+}
+
+.next-steps h3 {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.next-steps ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.next-steps li {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    font-size: 0.875rem;
+    color: var(--gray-600);
+    padding: 8px 0;
+}
+
+.next-steps li svg {
+    flex-shrink: 0;
+    color: var(--accent);
+    margin-top: 1px;
+}
+
+.action-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+}
+
 /* CTA */
 .cta {
     padding: 100px 24px;


### PR DESCRIPTION
## Summary

- Add missing CSS for onboarding wizard pages (`/onboarding/step/N` and `/onboarding/complete`) — pages were rendering without any layout styling
- Fix FK constraint error when creating a meeting template without a connected calendar

## Details

The onboarding template used CSS classes (`onboarding-container`, `progress-step`, `progress-line`, etc.) that had no definitions in style.css. The only matching class was `.step-number` from the landing page (64px circle), causing oversized step indicators and no layout structure.

The template FK fix converts empty `CalendarID` to `sql.NullString` in both `TemplateRepository.Create` and `Update`, so templates can be created without a calendar connection.

## Test plan

- [ ] Register a new user — onboarding step 1 shows centered card with horizontal progress bar and compact step circles
- [ ] Complete all 3 steps — `/onboarding/complete` page shows centered success layout with booking link and next steps cards
- [ ] Skip step 2 (calendar) and create a template in step 3 — no FK constraint error
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)