### PR TITLE
Visual Agenda PR2: week view with strip, day switching, and shared time axis

### DIFF
--- a/internal/handlers/dashboard.go
+++ b/internal/handlers/dashboard.go
@@ -1311,14 +1311,6 @@ func (h *DashboardHandler) AuditLogs(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// AgendaDayGroup represents a group of events for a single day
-type AgendaDayGroup struct {
-	Date   time.Time
-	Events []services.AgendaEvent
-}
-
-
-
 // Agenda renders the agenda view with today's or this week's events
 func (h *DashboardHandler) Agenda(w http.ResponseWriter, r *http.Request) {
 	host := middleware.GetHost(r.Context())
@@ -1343,8 +1335,6 @@ func (h *DashboardHandler) Agenda(w http.ResponseWriter, r *http.Request) {
 		view = "today"
 	}
 
-	var dayGroups []AgendaDayGroup
-
 	// today-view fields populated by AgendaService.GetDay
 	var agendaEvents []services.AgendaEvent
 	var agendaCalendars []*models.CalendarConnection
@@ -1352,23 +1342,33 @@ func (h *DashboardHandler) Agenda(w http.ResponseWriter, r *http.Request) {
 	var windowStart, windowEnd time.Time
 	var hourLabels []services.HourLabel
 
+	// week-view fields
+	var weekDays []services.WeekDayView
+	var weekMonday time.Time
+
 	if view == "week" {
-		// This Week: Monday to Sunday of current week
-		weekday := now.Weekday()
-		daysFromMonday := int(weekday) - 1
-		if weekday == time.Sunday {
-			daysFromMonday = 6
-		}
-		monday := time.Date(now.Year(), now.Month(), now.Day()-daysFromMonday, 0, 0, 0, 0, loc)
-		sunday := monday.AddDate(0, 0, 7)
-
-		weekEvents, fetchErr := h.handlers.services.Calendar.GetAgendaEvents(r.Context(), host.Host.ID, monday, sunday)
-		if fetchErr != nil {
-			log.Printf("Error fetching agenda events: %v", fetchErr)
-			weekEvents = []services.AgendaEvent{}
+		// Parse optional ?week=YYYY-MM-DD; if absent or malformed fall back to now.
+		weekParam := r.URL.Query().Get("week")
+		weekStart := now
+		if weekParam != "" {
+			if parsed, parseErr := time.Parse("2006-01-02", weekParam); parseErr == nil {
+				// Date-only parse yields UTC midnight; re-interpret as local midnight
+				// so GetWeek's .In(loc) reads the correct calendar date.
+				utcY, utcMo, utcD := parsed.UTC().Date()
+				weekStart = time.Date(utcY, utcMo, utcD, 0, 0, 0, 0, loc)
+			}
 		}
 
-		dayGroups = groupEventsByDay(weekEvents, monday, loc)
+		weekView, weekErr := h.handlers.services.Agenda.GetWeek(r.Context(), host.Host.ID, weekStart)
+		if weekErr != nil {
+			log.Printf("Error fetching week agenda: %v", weekErr)
+		} else {
+			windowStart, windowEnd = services.ComputeSharedWindow(weekView.Days)
+			hourLabels = services.GenerateHourLabels(windowStart, windowEnd)
+			weekDays = services.BuildWeekDayViews(weekView, windowStart, windowEnd, now)
+			agendaCalendars = weekView.Calendars
+			weekMonday = weekView.WeekStart
+		}
 	} else {
 		// Today: use AgendaService for palette-aware view composition.
 		agendaView, agendaErr := h.handlers.services.Agenda.GetDay(r.Context(), host.Host.ID, now)
@@ -1391,7 +1391,8 @@ func (h *DashboardHandler) Agenda(w http.ResponseWriter, r *http.Request) {
 		PendingCount: h.getPendingCount(r, host.Host.ID),
 		Data: map[string]interface{}{
 			"Events":      agendaEvents,
-			"DayGroups":   dayGroups,
+			"WeekDays":    weekDays,
+			"WeekMonday":  weekMonday,
 			"View":        view,
 			"Today":       now,
 			"Timezone":    host.Host.Timezone,
@@ -1402,35 +1403,6 @@ func (h *DashboardHandler) Agenda(w http.ResponseWriter, r *http.Request) {
 			"HourLabels":  hourLabels,
 		},
 	})
-}
-
-// groupEventsByDay groups events by their date and returns a slice of day groups
-func groupEventsByDay(events []services.AgendaEvent, weekStart time.Time, loc *time.Location) []AgendaDayGroup {
-	// Create groups for each day of the week
-	groups := make([]AgendaDayGroup, 7)
-	for i := 0; i < 7; i++ {
-		groups[i] = AgendaDayGroup{
-			Date:   weekStart.AddDate(0, 0, i),
-			Events: []services.AgendaEvent{},
-		}
-	}
-
-	// Assign events to their respective days
-	for _, event := range events {
-		eventDate := event.Start.In(loc)
-		dayOfWeek := eventDate.Weekday()
-		// Convert to Monday=0 index
-		dayIndex := int(dayOfWeek) - 1
-		if dayOfWeek == time.Sunday {
-			dayIndex = 6
-		}
-
-		if dayIndex >= 0 && dayIndex < 7 {
-			groups[dayIndex].Events = append(groups[dayIndex].Events, event)
-		}
-	}
-
-	return groups
 }
 
 // filterAvailableHosts returns hosts that are not already in the pooled hosts list

--- a/internal/services/agenda.go
+++ b/internal/services/agenda.go
@@ -149,29 +149,7 @@ func (s *AgendaService) GetWeek(ctx context.Context, hostID string, weekStart ti
 		days[i] = DayEvents{DayStart: dayStart, DayEnd: dayEnd}
 	}
 
-	for _, e := range events {
-		// For bucket assignment, all-day events must be interpreted in the host
-		// timezone. Calendar providers store all-day Start/End as UTC midnight
-		// values representing calendar dates (e.g. "2024-03-12" → 2024-03-12
-		// 00:00:00 UTC). For hosts west of UTC, UTC midnight falls on the
-		// previous calendar day locally, causing a Tuesday all-day event to
-		// overlap Monday's bucket. Re-interpret the UTC date as a local date
-		// before comparing. The original event (with UTC times) is stored
-		// unchanged so downstream detail views are unaffected.
-		eStart, eEnd := e.Start, e.End
-		if e.IsAllDay {
-			y, m, d := e.Start.UTC().Date()
-			eStart = time.Date(y, m, d, 0, 0, 0, 0, loc)
-			yE, mE, dE := e.End.UTC().Date()
-			eEnd = time.Date(yE, mE, dE, 0, 0, 0, 0, loc)
-		}
-		for i := range days {
-			// Event touches this day if it starts before dayEnd AND ends after dayStart.
-			if eStart.Before(days[i].DayEnd) && eEnd.After(days[i].DayStart) {
-				days[i].Events = append(days[i].Events, e)
-			}
-		}
-	}
+	assignEventsToBuckets(events, &days, loc)
 
 	// Sort each day's events by start time.
 	for i := range days {
@@ -186,4 +164,27 @@ func (s *AgendaService) GetWeek(ctx context.Context, hostID string, weekStart ti
 		WeekStart: monday,
 		HostTZ:    loc,
 	}, nil
+}
+
+// assignEventsToBuckets assigns each event to every day bucket it overlaps.
+// All-day events (stored as UTC midnight by calendar providers) are
+// re-interpreted in loc so that "2026-04-21 UTC" maps to April 21 locally
+// rather than the previous local day for west-of-UTC hosts. Original event
+// Start/End are stored unchanged so downstream detail views are unaffected.
+func assignEventsToBuckets(events []AgendaEvent, days *[7]DayEvents, loc *time.Location) {
+	for _, e := range events {
+		eStart, eEnd := e.Start, e.End
+		if e.IsAllDay {
+			y, m, d := e.Start.UTC().Date()
+			eStart = time.Date(y, m, d, 0, 0, 0, 0, loc)
+			yE, mE, dE := e.End.UTC().Date()
+			eEnd = time.Date(yE, mE, dE, 0, 0, 0, 0, loc)
+		}
+		for i := range days {
+			// Event touches this day if it starts before dayEnd AND ends after dayStart.
+			if eStart.Before(days[i].DayEnd) && eEnd.After(days[i].DayStart) {
+				days[i].Events = append(days[i].Events, e)
+			}
+		}
+	}
 }

--- a/internal/services/agenda.go
+++ b/internal/services/agenda.go
@@ -115,17 +115,22 @@ func (s *AgendaService) GetWeek(ctx context.Context, hostID string, weekStart ti
 	AssignColors(calendars)
 
 	// Normalize weekStart to 00:00 Monday of the containing week in host
-	// timezone. If weekStart is already a Monday only the time portion is
-	// zeroed; for any other weekday we step back to the preceding Monday so
-	// that callers may safely pass time.Now() or any in-week date.
-	localStart := weekStart.In(loc)
-	weekday := localStart.Weekday()
+	// timezone. Use the UTC date components of weekStart to derive the
+	// calendar date. Date-only values (e.g. from time.Parse("2006-01-02", s))
+	// are midnight UTC; calling .In(loc) on them shifts west-of-UTC hosts into
+	// the previous local day, causing the week calculation to back up by a full
+	// week. Reading the UTC date components and re-constructing local midnight
+	// avoids that shift while still correctly mapping any in-week instant.
+	// Callers may pass time.Now() (UTC) or any time representing the desired
+	// calendar date; the UTC date is used as the timezone-neutral date identity.
+	utcY, utcMo, utcD := weekStart.UTC().Date()
+	localDay := time.Date(utcY, utcMo, utcD, 0, 0, 0, 0, loc)
+	weekday := localDay.Weekday()
 	daysFromMonday := int(weekday) - 1
 	if weekday == time.Sunday {
 		daysFromMonday = 6
 	}
-	y, mo, d := localStart.Date()
-	monday := time.Date(y, mo, d-daysFromMonday, 0, 0, 0, 0, loc)
+	monday := localDay.AddDate(0, 0, -daysFromMonday)
 	nextMonday := monday.AddDate(0, 0, 7)
 
 	events, err := s.calendar.GetAgendaEventsWithCalendars(ctx, calendars, host, monday, nextMonday)

--- a/internal/services/agenda.go
+++ b/internal/services/agenda.go
@@ -114,9 +114,18 @@ func (s *AgendaService) GetWeek(ctx context.Context, hostID string, weekStart ti
 
 	AssignColors(calendars)
 
-	// Normalize weekStart to 00:00 Monday in host timezone.
+	// Normalize weekStart to 00:00 Monday of the containing week in host
+	// timezone. If weekStart is already a Monday only the time portion is
+	// zeroed; for any other weekday we step back to the preceding Monday so
+	// that callers may safely pass time.Now() or any in-week date.
 	localStart := weekStart.In(loc)
-	monday := time.Date(localStart.Year(), localStart.Month(), localStart.Day(), 0, 0, 0, 0, loc)
+	weekday := localStart.Weekday()
+	daysFromMonday := int(weekday) - 1
+	if weekday == time.Sunday {
+		daysFromMonday = 6
+	}
+	y, mo, d := localStart.Date()
+	monday := time.Date(y, mo, d-daysFromMonday, 0, 0, 0, 0, loc)
 	nextMonday := monday.AddDate(0, 0, 7)
 
 	events, err := s.calendar.GetAgendaEventsWithCalendars(ctx, calendars, host, monday, nextMonday)
@@ -124,11 +133,14 @@ func (s *AgendaService) GetWeek(ctx context.Context, hostID string, weekStart ti
 		return nil, fmt.Errorf("fetch events: %w", err)
 	}
 
-	// Build 7 day buckets and assign events to all days they touch.
+	// Build 7 day buckets using calendar-date arithmetic so that DST
+	// transitions (spring-forward / fall-back) do not shift the bucket
+	// boundary away from local midnight. AddDate always lands on the
+	// calendar day's 00:00 in the target location.
 	var days [7]DayEvents
 	for i := range 7 {
 		dayStart := monday.AddDate(0, 0, i)
-		dayEnd := dayStart.Add(24 * time.Hour)
+		dayEnd := monday.AddDate(0, 0, i+1)
 		days[i] = DayEvents{DayStart: dayStart, DayEnd: dayEnd}
 	}
 

--- a/internal/services/agenda.go
+++ b/internal/services/agenda.go
@@ -145,9 +145,24 @@ func (s *AgendaService) GetWeek(ctx context.Context, hostID string, weekStart ti
 	}
 
 	for _, e := range events {
+		// For bucket assignment, all-day events must be interpreted in the host
+		// timezone. Calendar providers store all-day Start/End as UTC midnight
+		// values representing calendar dates (e.g. "2024-03-12" → 2024-03-12
+		// 00:00:00 UTC). For hosts west of UTC, UTC midnight falls on the
+		// previous calendar day locally, causing a Tuesday all-day event to
+		// overlap Monday's bucket. Re-interpret the UTC date as a local date
+		// before comparing. The original event (with UTC times) is stored
+		// unchanged so downstream detail views are unaffected.
+		eStart, eEnd := e.Start, e.End
+		if e.IsAllDay {
+			y, m, d := e.Start.UTC().Date()
+			eStart = time.Date(y, m, d, 0, 0, 0, 0, loc)
+			yE, mE, dE := e.End.UTC().Date()
+			eEnd = time.Date(yE, mE, dE, 0, 0, 0, 0, loc)
+		}
 		for i := range days {
 			// Event touches this day if it starts before dayEnd AND ends after dayStart.
-			if e.Start.Before(days[i].DayEnd) && e.End.After(days[i].DayStart) {
+			if eStart.Before(days[i].DayEnd) && eEnd.After(days[i].DayStart) {
 				days[i].Events = append(days[i].Events, e)
 			}
 		}

--- a/internal/services/agenda.go
+++ b/internal/services/agenda.go
@@ -115,22 +115,22 @@ func (s *AgendaService) GetWeek(ctx context.Context, hostID string, weekStart ti
 	AssignColors(calendars)
 
 	// Normalize weekStart to 00:00 Monday of the containing week in host
-	// timezone. Use the UTC date components of weekStart to derive the
-	// calendar date. Date-only values (e.g. from time.Parse("2006-01-02", s))
-	// are midnight UTC; calling .In(loc) on them shifts west-of-UTC hosts into
-	// the previous local day, causing the week calculation to back up by a full
-	// week. Reading the UTC date components and re-constructing local midnight
-	// avoids that shift while still correctly mapping any in-week instant.
-	// Callers may pass time.Now() (UTC) or any time representing the desired
-	// calendar date; the UTC date is used as the timezone-neutral date identity.
-	utcY, utcMo, utcD := weekStart.UTC().Date()
-	localDay := time.Date(utcY, utcMo, utcD, 0, 0, 0, 0, loc)
-	weekday := localDay.Weekday()
+	// timezone. weekStart must already carry the correct local instant — either
+	// time.Now().In(loc) or a date-only parse reinterpreted as local midnight:
+	//
+	//   utcY, utcMo, utcD := parsed.UTC().Date()
+	//   weekStart = time.Date(utcY, utcMo, utcD, 0, 0, 0, 0, loc)
+	//
+	// Using .UTC().Date() inside GetWeek would break positive-offset hosts:
+	// e.g. 2026-04-20 00:00 JST → UTC April 19 → week backs up to April 13.
+	localStart := weekStart.In(loc)
+	y, mo, d := localStart.Date()
+	weekday := localStart.Weekday()
 	daysFromMonday := int(weekday) - 1
 	if weekday == time.Sunday {
 		daysFromMonday = 6
 	}
-	monday := localDay.AddDate(0, 0, -daysFromMonday)
+	monday := time.Date(y, mo, d-daysFromMonday, 0, 0, 0, 0, loc)
 	nextMonday := monday.AddDate(0, 0, 7)
 
 	events, err := s.calendar.GetAgendaEventsWithCalendars(ctx, calendars, host, monday, nextMonday)

--- a/internal/services/agenda.go
+++ b/internal/services/agenda.go
@@ -10,6 +10,23 @@ import (
 	"github.com/meet-when/meet-when/internal/repository"
 )
 
+// DayEvents holds the events that touch a single calendar day.
+// Events are NOT clipped to day boundaries — the original Start/End are
+// preserved so the detail list can show the full duration of overnight events.
+type DayEvents struct {
+	DayStart time.Time
+	DayEnd   time.Time
+	Events   []AgendaEvent
+}
+
+// WeekView is the view model for a full 7-day week.
+type WeekView struct {
+	Calendars []*models.CalendarConnection
+	Days      [7]DayEvents
+	WeekStart time.Time
+	HostTZ    *time.Location
+}
+
 // AgendaService composes the full agenda day view model.
 type AgendaService struct {
 	repos    *repository.Repositories
@@ -69,6 +86,72 @@ func (s *AgendaService) GetDay(ctx context.Context, hostID string, date time.Tim
 		Events:    events,
 		DayStart:  dayStart,
 		DayEnd:    dayEnd,
+		HostTZ:    loc,
+	}, nil
+}
+
+// GetWeek returns a WeekView for the 7-day period starting on weekStart (a
+// Monday in the host's timezone). Events are assigned to each day they touch
+// (event.Start < dayEnd AND event.End > dayStart) without clipping — the
+// original Start/End are preserved so overnight events appear with their full
+// duration in the detail list. Events appear in BOTH days they span across
+// midnight. Each day's events are sorted by start time.
+func (s *AgendaService) GetWeek(ctx context.Context, hostID string, weekStart time.Time) (*WeekView, error) {
+	host, err := s.repos.Host.GetByID(ctx, hostID)
+	if err != nil {
+		return nil, fmt.Errorf("load host: %w", err)
+	}
+
+	loc, err := time.LoadLocation(host.Timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+
+	calendars, err := s.repos.Calendar.GetByHostID(ctx, hostID)
+	if err != nil {
+		return nil, fmt.Errorf("load calendars: %w", err)
+	}
+
+	AssignColors(calendars)
+
+	// Normalize weekStart to 00:00 Monday in host timezone.
+	localStart := weekStart.In(loc)
+	monday := time.Date(localStart.Year(), localStart.Month(), localStart.Day(), 0, 0, 0, 0, loc)
+	nextMonday := monday.AddDate(0, 0, 7)
+
+	events, err := s.calendar.GetAgendaEventsWithCalendars(ctx, calendars, host, monday, nextMonday)
+	if err != nil {
+		return nil, fmt.Errorf("fetch events: %w", err)
+	}
+
+	// Build 7 day buckets and assign events to all days they touch.
+	var days [7]DayEvents
+	for i := range 7 {
+		dayStart := monday.AddDate(0, 0, i)
+		dayEnd := dayStart.Add(24 * time.Hour)
+		days[i] = DayEvents{DayStart: dayStart, DayEnd: dayEnd}
+	}
+
+	for _, e := range events {
+		for i := range days {
+			// Event touches this day if it starts before dayEnd AND ends after dayStart.
+			if e.Start.Before(days[i].DayEnd) && e.End.After(days[i].DayStart) {
+				days[i].Events = append(days[i].Events, e)
+			}
+		}
+	}
+
+	// Sort each day's events by start time.
+	for i := range days {
+		slices.SortFunc(days[i].Events, func(a, b AgendaEvent) int {
+			return a.Start.Compare(b.Start)
+		})
+	}
+
+	return &WeekView{
+		Calendars: calendars,
+		Days:      days,
+		WeekStart: monday,
 		HostTZ:    loc,
 	}, nil
 }

--- a/internal/services/agenda_strip.go
+++ b/internal/services/agenda_strip.go
@@ -9,11 +9,13 @@ import (
 
 // StripBlock represents a single event positioned within the visible day strip.
 type StripBlock struct {
-	LeftPct float64 // percentage from the left edge of the visible window
-	WidthPct float64 // percentage of the visible window width
-	Color   string
-	Title   string
-	EventID string
+	LeftPct       float64 // percentage from the left edge of the visible window
+	WidthPct      float64 // percentage of the visible window width
+	Color         string
+	Title         string
+	EventID       string
+	OverflowLeft  bool // event's original start is before windowStart
+	OverflowRight bool // event's original end is after windowEnd
 }
 
 // CalendarLane holds positioned blocks for one calendar within the day strip.
@@ -199,11 +201,13 @@ func LanesByCalendar(view *AgendaView) []CalendarLane {
 			}
 
 			blocks = append(blocks, StripBlock{
-				LeftPct:  leftPct,
-				WidthPct: widthPct,
-				Color:    color,
-				Title:    e.Title,
-				EventID:  e.ID,
+				LeftPct:       leftPct,
+				WidthPct:      widthPct,
+				Color:         color,
+				Title:         e.Title,
+				EventID:       e.ID,
+				OverflowLeft:  e.Start.Before(winStart),
+				OverflowRight: e.End.After(winEnd),
 			})
 		}
 
@@ -215,4 +219,187 @@ func LanesByCalendar(view *AgendaView) []CalendarLane {
 	}
 
 	return lanes
+}
+
+// ComputeSharedWindow returns a single visible time window that covers all
+// non-all-day events across all 7 days of a week. It applies the same adaptive
+// logic as ComputeVisibleWindow: baseline 09:00–18:00 in the first day's
+// location, extended 30 minutes before the earliest start and after the latest
+// end, contracted when events end earlier. If there are no timed events the
+// 09:00–18:00 baseline is returned using the first day's location. The returned
+// times use the first day's timezone so all day columns share identical offsets.
+func ComputeSharedWindow(days [7]DayEvents) (time.Time, time.Time) {
+	const padding = 30 * time.Minute
+
+	// Use the first day's location for the baseline.
+	loc := days[0].DayStart.Location()
+	y, m, d := days[0].DayStart.Date()
+	winStart := time.Date(y, m, d, 9, 0, 0, 0, loc)
+	winEnd := time.Date(y, m, d, 18, 0, 0, 0, loc)
+
+	var minStart, maxEnd time.Time
+	hasTimedEvent := false
+	for _, day := range days {
+		for _, e := range day.Events {
+			if e.IsAllDay {
+				continue
+			}
+			if !hasTimedEvent || e.Start.Before(minStart) {
+				minStart = e.Start
+			}
+			if !hasTimedEvent || e.End.After(maxEnd) {
+				maxEnd = e.End
+			}
+			hasTimedEvent = true
+		}
+	}
+
+	if hasTimedEvent {
+		if padded := minStart.Add(-padding); padded.Before(winStart) {
+			winStart = padded
+		}
+		winEnd = maxEnd.Add(padding)
+	}
+
+	// Clamp to [days[0].DayStart, days[6].DayEnd].
+	if winStart.Before(days[0].DayStart) {
+		winStart = days[0].DayStart
+	}
+	if winEnd.After(days[6].DayEnd) {
+		winEnd = days[6].DayEnd
+	}
+
+	return winStart, winEnd
+}
+
+// FlatLane converts a slice of AgendaEvents into a single flat lane of
+// StripBlocks positioned within [windowStart, windowEnd]. All-day events are
+// excluded. Events from all calendars are overlaid into one lane (unlike
+// LanesByCalendar which separates by calendar). Each block is clipped to the
+// window boundary; events that extend beyond the window get OverflowLeft or
+// OverflowRight set to true so templates can render edge arrow indicators.
+func FlatLane(events []AgendaEvent, windowStart, windowEnd time.Time) []StripBlock {
+	winDuration := windowEnd.Sub(windowStart).Seconds()
+	if winDuration <= 0 {
+		return nil
+	}
+
+	blocks := make([]StripBlock, 0, len(events))
+	for _, e := range events {
+		if e.IsAllDay {
+			continue
+		}
+
+		// Determine overflow before clipping.
+		overflowLeft := e.Start.Before(windowStart)
+		overflowRight := e.End.After(windowEnd)
+
+		// Clip to window boundary.
+		eStart := e.Start
+		eEnd := e.End
+		if eStart.Before(windowStart) {
+			eStart = windowStart
+		}
+		if eEnd.After(windowEnd) {
+			eEnd = windowEnd
+		}
+		if !eEnd.After(eStart) {
+			continue
+		}
+
+		leftPct := eStart.Sub(windowStart).Seconds() / winDuration * 100
+		widthPct := eEnd.Sub(eStart).Seconds() / winDuration * 100
+
+		// Clamp so the block does not overflow the right edge due to float arithmetic.
+		if leftPct+widthPct > 100 {
+			widthPct = 100 - leftPct
+		}
+		if widthPct < 0 {
+			widthPct = 0
+		}
+
+		color := e.CalendarColor
+		if color == "" {
+			color = "#5F5E5A"
+		}
+
+		blocks = append(blocks, StripBlock{
+			LeftPct:       leftPct,
+			WidthPct:      widthPct,
+			Color:         color,
+			Title:         e.Title,
+			EventID:       e.ID,
+			OverflowLeft:  overflowLeft,
+			OverflowRight: overflowRight,
+		})
+	}
+	return blocks
+}
+
+// WeekDayView bundles all per-day data needed to render one row of the week
+// strip and its corresponding detail panel.
+type WeekDayView struct {
+	Date              time.Time
+	DayName           string // e.g. "Mon"
+	DateFormatted     string // e.g. "Apr 13"
+	FullDateFormatted string // e.g. "Monday, April 13"
+	Blocks            []StripBlock
+	Events            []AgendaEvent // original unclipped events for the detail list
+	EventCount        int
+	IsToday           bool
+	IsActive          bool
+}
+
+// BuildWeekDayViews produces 7 WeekDayViews for the given week. Blocks are
+// positioned within [sharedWindowStart, sharedWindowEnd] via FlatLane. Events
+// are the original unclipped events from DayEvents for use in the detail panel.
+// IsToday is set for the day whose calendar date matches today. IsActive is set
+// for today (or for the first day that has events when today has none).
+func BuildWeekDayViews(week *WeekView, sharedWindowStart, sharedWindowEnd time.Time, today time.Time) []WeekDayView {
+	todayLocal := today.In(week.HostTZ)
+	todayY, todayM, todayD := todayLocal.Date()
+
+	views := make([]WeekDayView, 7)
+	activeFallback := -1 // index of first day with events
+
+	for i, day := range week.Days {
+		dayLocal := day.DayStart.In(week.HostTZ)
+		y, m, d := dayLocal.Date()
+		isToday := y == todayY && m == todayM && d == todayD
+
+		views[i] = WeekDayView{
+			Date:              day.DayStart,
+			DayName:           dayLocal.Format("Mon"),
+			DateFormatted:     dayLocal.Format("Jan 2"),
+			FullDateFormatted: dayLocal.Format("Monday, January 2"),
+			Blocks:            FlatLane(day.Events, sharedWindowStart, sharedWindowEnd),
+			Events:            day.Events,
+			EventCount:        len(day.Events),
+			IsToday:           isToday,
+		}
+
+		if activeFallback == -1 && len(day.Events) > 0 {
+			activeFallback = i
+		}
+	}
+
+	// Set IsActive: today if today is in this week, else first day with events,
+	// else Monday (index 0).
+	activeSet := false
+	for i := range views {
+		if views[i].IsToday {
+			views[i].IsActive = true
+			activeSet = true
+			break
+		}
+	}
+	if !activeSet {
+		idx := activeFallback
+		if idx == -1 {
+			idx = 0
+		}
+		views[idx].IsActive = true
+	}
+
+	return views
 }

--- a/internal/services/agenda_strip.go
+++ b/internal/services/agenda_strip.go
@@ -221,52 +221,74 @@ func LanesByCalendar(view *AgendaView) []CalendarLane {
 	return lanes
 }
 
-// ComputeSharedWindow returns a single visible time window that covers all
-// non-all-day events across all 7 days of a week. It applies the same adaptive
-// logic as ComputeVisibleWindow: baseline 09:00–18:00 in the first day's
-// location, extended 30 minutes before the earliest start and after the latest
-// end, contracted when events end earlier. If there are no timed events the
-// 09:00–18:00 baseline is returned using the first day's location. The returned
-// times use the first day's timezone so all day columns share identical offsets.
+// ComputeSharedWindow returns a single visible time window expressed on day 0
+// (Monday) that covers all non-all-day events across all 7 days. It applies
+// the same adaptive logic as ComputeVisibleWindow: baseline 09:00–18:00,
+// extended 30 minutes before the earliest start and after the latest end.
+//
+// Critically, the window is derived from time-of-day only — each event's
+// start/end is clipped to its own day boundary, then converted to an offset
+// from that day's midnight. This ensures the returned window is a pure
+// time-of-day range: e.g. 07:30–19:30 on day 0. Callers (BuildWeekDayViews)
+// shift this to each day's own coordinates before calling FlatLane, so every
+// day row aligns with the shared hour-label header.
 func ComputeSharedWindow(days [7]DayEvents) (time.Time, time.Time) {
 	const padding = 30 * time.Minute
 
-	// Use the first day's location for the baseline.
+	// Express baseline on day 0.
 	loc := days[0].DayStart.Location()
 	y, m, d := days[0].DayStart.Date()
 	winStart := time.Date(y, m, d, 9, 0, 0, 0, loc)
 	winEnd := time.Date(y, m, d, 18, 0, 0, 0, loc)
 
-	var minStart, maxEnd time.Time
+	// Track min/max as time-of-day durations from midnight.
+	var minTOD, maxTOD time.Duration
 	hasTimedEvent := false
 	for _, day := range days {
 		for _, e := range day.Events {
 			if e.IsAllDay {
 				continue
 			}
-			if !hasTimedEvent || e.Start.Before(minStart) {
-				minStart = e.Start
+			// Clip event to this day's boundaries before measuring TOD so that
+			// overnight events (e.g. 22:00 Mon → 02:00 Tue) contribute at most
+			// 00:00–24:00 on each day they appear in.
+			eStart := e.Start
+			eEnd := e.End
+			if eStart.Before(day.DayStart) {
+				eStart = day.DayStart
 			}
-			if !hasTimedEvent || e.End.After(maxEnd) {
-				maxEnd = e.End
+			if eEnd.After(day.DayEnd) {
+				eEnd = day.DayEnd
+			}
+			if !eEnd.After(eStart) {
+				continue
+			}
+			startTOD := eStart.Sub(day.DayStart)
+			endTOD := eEnd.Sub(day.DayStart)
+
+			if !hasTimedEvent || startTOD < minTOD {
+				minTOD = startTOD
+			}
+			if !hasTimedEvent || endTOD > maxTOD {
+				maxTOD = endTOD
 			}
 			hasTimedEvent = true
 		}
 	}
 
 	if hasTimedEvent {
-		if padded := minStart.Add(-padding); padded.Before(winStart) {
+		if padded := days[0].DayStart.Add(minTOD - padding); padded.Before(winStart) {
 			winStart = padded
 		}
-		winEnd = maxEnd.Add(padding)
+		winEnd = days[0].DayStart.Add(maxTOD + padding)
 	}
 
-	// Clamp to [days[0].DayStart, days[6].DayEnd].
+	// Clamp to [days[0].DayStart, days[0].DayEnd] — one calendar day.
 	if winStart.Before(days[0].DayStart) {
 		winStart = days[0].DayStart
 	}
-	if winEnd.After(days[6].DayEnd) {
-		winEnd = days[6].DayEnd
+	if winEnd.After(days[0].DayEnd) {
+		winEnd = days[0].DayEnd
 	}
 
 	return winStart, winEnd
@@ -351,13 +373,24 @@ type WeekDayView struct {
 }
 
 // BuildWeekDayViews produces 7 WeekDayViews for the given week. Blocks are
-// positioned within [sharedWindowStart, sharedWindowEnd] via FlatLane. Events
-// are the original unclipped events from DayEvents for use in the detail panel.
+// positioned within the shared time-of-day window via FlatLane. Events are the
+// original unclipped events from DayEvents for use in the detail panel.
 // IsToday is set for the day whose calendar date matches today. IsActive is set
 // for today (or for the first day that has events when today has none).
+//
+// sharedWindowStart and sharedWindowEnd are expressed on day 0 (Monday). They
+// represent a time-of-day range (e.g. Monday 07:30–Monday 19:30). For each day
+// row, the window is shifted to that day's own coordinates before calling
+// FlatLane, ensuring every row's blocks align with the shared hour-label header.
 func BuildWeekDayViews(week *WeekView, sharedWindowStart, sharedWindowEnd time.Time, today time.Time) []WeekDayView {
 	todayLocal := today.In(week.HostTZ)
 	todayY, todayM, todayD := todayLocal.Date()
+
+	// sharedWindowStart/End are on day 0. Compute offsets from day 0's midnight
+	// so we can re-anchor the window onto each day.
+	day0Start := week.Days[0].DayStart
+	windowStartOffset := sharedWindowStart.Sub(day0Start)
+	windowEndOffset := sharedWindowEnd.Sub(day0Start)
 
 	views := make([]WeekDayView, 7)
 	activeFallback := -1 // index of first day with events
@@ -367,12 +400,16 @@ func BuildWeekDayViews(week *WeekView, sharedWindowStart, sharedWindowEnd time.T
 		y, m, d := dayLocal.Date()
 		isToday := y == todayY && m == todayM && d == todayD
 
+		// Shift the shared window to this day's coordinates.
+		dayWindowStart := day.DayStart.Add(windowStartOffset)
+		dayWindowEnd := day.DayStart.Add(windowEndOffset)
+
 		views[i] = WeekDayView{
 			Date:              day.DayStart,
 			DayName:           dayLocal.Format("Mon"),
 			DateFormatted:     dayLocal.Format("Jan 2"),
 			FullDateFormatted: dayLocal.Format("Monday, January 2"),
-			Blocks:            FlatLane(day.Events, sharedWindowStart, sharedWindowEnd),
+			Blocks:            FlatLane(day.Events, dayWindowStart, dayWindowEnd),
 			Events:            day.Events,
 			EventCount:        len(day.Events),
 			IsToday:           isToday,

--- a/internal/services/agenda_strip_test.go
+++ b/internal/services/agenda_strip_test.go
@@ -470,10 +470,10 @@ func TestComputeSharedWindow_EventsOnMondayAndThursday(t *testing.T) {
 	days := buildWeekDays(loc, map[int][]AgendaEvent{0: {evtMon}, 3: {evtThu}})
 	winStart, winEnd := ComputeSharedWindow(days)
 
-	// minStart = 08:00 Mon → padded 07:30 < baseline 09:00 → winStart = 07:30
+	// minStart = 08:00 Mon → padded 07:30 < baseline 09:00 → winStart = 07:30 (day 0)
 	wantStart := time.Date(monday.Year(), monday.Month(), monday.Day(), 7, 30, 0, 0, loc)
-	// maxEnd = 20:00 Thu → winEnd = 20:30 Thu
-	wantEnd := time.Date(thursday.Year(), thursday.Month(), thursday.Day(), 20, 30, 0, 0, loc)
+	// maxTOD = 20:00 (Thu's TOD) → winEnd = Monday 20:30 (day-0 coordinates)
+	wantEnd := time.Date(monday.Year(), monday.Month(), monday.Day(), 20, 30, 0, 0, loc)
 
 	if !winStart.Equal(wantStart) {
 		t.Errorf("winStart: want %v, got %v", wantStart, winStart)
@@ -532,10 +532,12 @@ func TestComputeSharedWindow_FlatLaneIntegration(t *testing.T) {
 		t.Errorf("winStart %v should be at or before %v (early event not covered)", winStart, latestAllowedStart)
 	}
 
-	// winEnd should cover 21:00 Thu + 30min = 21:30 Thu
-	earliestAllowedEnd := time.Date(thursday.Year(), thursday.Month(), thursday.Day(), 21, 30, 0, 0, loc)
+	// winEnd should represent 21:30 time-of-day on day 0 (Monday coordinates).
+	// The late Thursday event contributes TOD 21:00 + 30min padding = 21:30, and
+	// ComputeSharedWindow expresses that as Monday 21:30.
+	earliestAllowedEnd := time.Date(monday.Year(), monday.Month(), monday.Day(), 21, 30, 0, 0, loc)
 	if winEnd.Before(earliestAllowedEnd) {
-		t.Errorf("winEnd %v should be at or after %v (late event not covered)", winEnd, earliestAllowedEnd)
+		t.Errorf("winEnd %v should be at or after %v (late event TOD not covered)", winEnd, earliestAllowedEnd)
 	}
 
 	// Now add a Saturday event that starts before winStart — FlatLane should

--- a/internal/services/agenda_strip_test.go
+++ b/internal/services/agenda_strip_test.go
@@ -354,6 +354,212 @@ func TestLanesByCalendar_LeftPctPlusWidthPctNeverExceeds100(t *testing.T) {
 	}
 }
 
+// ─── FlatLane ────────────────────────────────────────────────────────────────
+
+// TestFlatLane_TwoCalendarsTwoBlocks verifies that 2 events from different
+// calendars on the same day produce 2 blocks in the flat lane.
+func TestFlatLane_TwoCalendarsTwoBlocks(t *testing.T) {
+	loc := time.UTC
+	winStart := time.Date(2024, 3, 15, 9, 0, 0, 0, loc)
+	winEnd := time.Date(2024, 3, 15, 18, 0, 0, 0, loc)
+
+	e1 := newEvent("c1", "#378ADD", localTime(loc, 10, 0), localTime(loc, 11, 0), false)
+	e2 := newEvent("c2", "#1D9E75", localTime(loc, 14, 0), localTime(loc, 15, 0), false)
+
+	blocks := FlatLane([]AgendaEvent{e1, e2}, winStart, winEnd)
+	if len(blocks) != 2 {
+		t.Errorf("want 2 blocks, got %d", len(blocks))
+	}
+}
+
+// TestFlatLane_AllDayEventsExcluded verifies that all-day events are not
+// converted to strip blocks by FlatLane.
+func TestFlatLane_AllDayEventsExcluded(t *testing.T) {
+	loc := time.UTC
+	winStart := time.Date(2024, 3, 15, 9, 0, 0, 0, loc)
+	winEnd := time.Date(2024, 3, 15, 18, 0, 0, 0, loc)
+
+	allDay := newEvent("c1", "#378ADD", localTime(loc, 0, 0), localTime(loc, 0, 0), true)
+	timed := newEvent("c2", "#1D9E75", localTime(loc, 10, 0), localTime(loc, 11, 0), false)
+
+	blocks := FlatLane([]AgendaEvent{allDay, timed}, winStart, winEnd)
+	if len(blocks) != 1 {
+		t.Errorf("want 1 block (all-day excluded), got %d", len(blocks))
+	}
+}
+
+// TestFlatLane_OverflowLeft verifies that an event starting before windowStart
+// produces a block with OverflowLeft=true and LeftPct=0.
+func TestFlatLane_OverflowLeft(t *testing.T) {
+	loc := time.UTC
+	winStart := time.Date(2024, 3, 15, 9, 0, 0, 0, loc)
+	winEnd := time.Date(2024, 3, 15, 18, 0, 0, 0, loc)
+
+	// Event starts at 07:00, before the 09:00 window start.
+	e := newEvent("c1", "#378ADD", localTime(loc, 7, 0), localTime(loc, 10, 0), false)
+	blocks := FlatLane([]AgendaEvent{e}, winStart, winEnd)
+
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	b := blocks[0]
+	if !b.OverflowLeft {
+		t.Error("OverflowLeft should be true for event starting before windowStart")
+	}
+	if b.LeftPct != 0 {
+		t.Errorf("LeftPct should be 0 for overflow-left block, got %.4f", b.LeftPct)
+	}
+}
+
+// TestFlatLane_OverflowRight verifies that an event ending after windowEnd
+// produces a block with OverflowRight=true.
+func TestFlatLane_OverflowRight(t *testing.T) {
+	loc := time.UTC
+	winStart := time.Date(2024, 3, 15, 9, 0, 0, 0, loc)
+	winEnd := time.Date(2024, 3, 15, 18, 0, 0, 0, loc)
+
+	// Event ends at 20:00, after the 18:00 window end.
+	e := newEvent("c1", "#378ADD", localTime(loc, 16, 0), localTime(loc, 20, 0), false)
+	blocks := FlatLane([]AgendaEvent{e}, winStart, winEnd)
+
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	b := blocks[0]
+	if !b.OverflowRight {
+		t.Error("OverflowRight should be true for event ending after windowEnd")
+	}
+}
+
+// ─── ComputeSharedWindow ─────────────────────────────────────────────────────
+
+func buildWeekDays(loc *time.Location, events map[int][]AgendaEvent) [7]DayEvents {
+	monday := time.Date(2024, 4, 14, 0, 0, 0, 0, loc) // a known Monday
+	var days [7]DayEvents
+	for i := range 7 {
+		days[i] = DayEvents{
+			DayStart: monday.AddDate(0, 0, i),
+			DayEnd:   monday.AddDate(0, 0, i+1),
+		}
+		if evts, ok := events[i]; ok {
+			days[i].Events = evts
+		}
+	}
+	return days
+}
+
+// TestComputeSharedWindow_EventsOnMondayAndThursday verifies that events on
+// non-adjacent days both influence the shared window.
+func TestComputeSharedWindow_EventsOnMondayAndThursday(t *testing.T) {
+	loc := time.UTC
+	monday := time.Date(2024, 4, 14, 0, 0, 0, 0, loc)
+	thursday := monday.AddDate(0, 0, 3)
+
+	// Monday 08:00-09:00, Thursday 19:00-20:00
+	evtMon := AgendaEvent{
+		ID: "mon", Title: "Mon",
+		Start: time.Date(monday.Year(), monday.Month(), monday.Day(), 8, 0, 0, 0, loc),
+		End:   time.Date(monday.Year(), monday.Month(), monday.Day(), 9, 0, 0, 0, loc),
+	}
+	evtThu := AgendaEvent{
+		ID: "thu", Title: "Thu",
+		Start: time.Date(thursday.Year(), thursday.Month(), thursday.Day(), 19, 0, 0, 0, loc),
+		End:   time.Date(thursday.Year(), thursday.Month(), thursday.Day(), 20, 0, 0, 0, loc),
+	}
+
+	days := buildWeekDays(loc, map[int][]AgendaEvent{0: {evtMon}, 3: {evtThu}})
+	winStart, winEnd := ComputeSharedWindow(days)
+
+	// minStart = 08:00 Mon → padded 07:30 < baseline 09:00 → winStart = 07:30
+	wantStart := time.Date(monday.Year(), monday.Month(), monday.Day(), 7, 30, 0, 0, loc)
+	// maxEnd = 20:00 Thu → winEnd = 20:30 Thu
+	wantEnd := time.Date(thursday.Year(), thursday.Month(), thursday.Day(), 20, 30, 0, 0, loc)
+
+	if !winStart.Equal(wantStart) {
+		t.Errorf("winStart: want %v, got %v", wantStart, winStart)
+	}
+	if !winEnd.Equal(wantEnd) {
+		t.Errorf("winEnd: want %v, got %v", wantEnd, winEnd)
+	}
+}
+
+// TestComputeSharedWindow_EmptyWeekReturnsBaseline verifies that a week with no
+// timed events returns the 09:00-18:00 baseline in the first day's timezone.
+func TestComputeSharedWindow_EmptyWeekReturnsBaseline(t *testing.T) {
+	loc := time.UTC
+	days := buildWeekDays(loc, nil)
+	winStart, winEnd := ComputeSharedWindow(days)
+
+	y, m, d := days[0].DayStart.Date()
+	wantStart := time.Date(y, m, d, 9, 0, 0, 0, loc)
+	wantEnd := time.Date(y, m, d, 18, 0, 0, 0, loc)
+
+	if !winStart.Equal(wantStart) {
+		t.Errorf("winStart: want %v, got %v", wantStart, winStart)
+	}
+	if !winEnd.Equal(wantEnd) {
+		t.Errorf("winEnd: want %v, got %v", wantEnd, winEnd)
+	}
+}
+
+// TestComputeSharedWindow_FlatLaneIntegration verifies that when a week has an
+// event at 07:00 Mon and 20:00 Thu, the shared window covers both and FlatLane
+// for a day with an event starting before the shared window produces a block
+// with OverflowLeft=true and LeftPct=0.
+func TestComputeSharedWindow_FlatLaneIntegration(t *testing.T) {
+	loc := time.UTC
+	monday := time.Date(2024, 4, 14, 0, 0, 0, 0, loc)
+	thursday := monday.AddDate(0, 0, 3)
+
+	// Monday 07:00-08:00 (before 09:00 baseline — will push window left)
+	evtMon := AgendaEvent{
+		ID: "mon", Title: "Early Mon",
+		Start: time.Date(monday.Year(), monday.Month(), monday.Day(), 7, 0, 0, 0, loc),
+		End:   time.Date(monday.Year(), monday.Month(), monday.Day(), 8, 0, 0, 0, loc),
+	}
+	// Thursday 20:00-21:00
+	evtThu := AgendaEvent{
+		ID: "thu", Title: "Late Thu",
+		Start: time.Date(thursday.Year(), thursday.Month(), thursday.Day(), 20, 0, 0, 0, loc),
+		End:   time.Date(thursday.Year(), thursday.Month(), thursday.Day(), 21, 0, 0, 0, loc),
+	}
+	days := buildWeekDays(loc, map[int][]AgendaEvent{0: {evtMon}, 3: {evtThu}})
+	winStart, winEnd := ComputeSharedWindow(days)
+
+	// winStart should be at most 06:30 (07:00 - 30min padding)
+	latestAllowedStart := time.Date(monday.Year(), monday.Month(), monday.Day(), 6, 30, 0, 0, loc)
+	if winStart.After(latestAllowedStart) {
+		t.Errorf("winStart %v should be at or before %v (early event not covered)", winStart, latestAllowedStart)
+	}
+
+	// winEnd should cover 21:00 Thu + 30min = 21:30 Thu
+	earliestAllowedEnd := time.Date(thursday.Year(), thursday.Month(), thursday.Day(), 21, 30, 0, 0, loc)
+	if winEnd.Before(earliestAllowedEnd) {
+		t.Errorf("winEnd %v should be at or after %v (late event not covered)", winEnd, earliestAllowedEnd)
+	}
+
+	// Now add a Saturday event that starts before winStart — FlatLane should
+	// produce a block with OverflowLeft=true and LeftPct=0.
+	saturday := monday.AddDate(0, 0, 5)
+	earlyEvt := AgendaEvent{
+		ID: "sat", Title: "Before window",
+		// Start 30 min before winStart
+		Start: winStart.Add(-30 * time.Minute),
+		End:   winStart.Add(30 * time.Minute),
+	}
+	blocks := FlatLane([]AgendaEvent{earlyEvt}, winStart, winEnd)
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d (saturday=%v)", len(blocks), saturday)
+	}
+	b := blocks[0]
+	if !b.OverflowLeft {
+		t.Error("OverflowLeft should be true for event starting before shared window")
+	}
+	if b.LeftPct != 0 {
+		t.Errorf("LeftPct should be 0 for overflow-left block, got %.4f", b.LeftPct)
+	}
+}
+
 // TestLanesByCalendar_DSTSpringForward verifies that an event spanning the
 // spring-forward transition (America/New_York, 2024-03-10 02:00 → 03:00) is
 // positioned correctly based on wall-clock duration.

--- a/internal/services/agenda_test.go
+++ b/internal/services/agenda_test.go
@@ -1,0 +1,112 @@
+package services
+
+import (
+	"testing"
+	"time"
+)
+
+// buildWeekBuckets creates a [7]DayEvents rooted at monday in loc, matching
+// the same AddDate arithmetic used in GetWeek.
+func buildWeekBuckets(monday time.Time) [7]DayEvents {
+	var days [7]DayEvents
+	for i := range 7 {
+		days[i] = DayEvents{
+			DayStart: monday.AddDate(0, 0, i),
+			DayEnd:   monday.AddDate(0, 0, i+1),
+		}
+	}
+	return days
+}
+
+// ─── assignEventsToBuckets ───────────────────────────────────────────────────
+
+// TestAssignEventsToBuckets_OvernightEventAppearsInBothDays verifies that an
+// event starting 22:00 Monday and ending 02:00 Tuesday is assigned to BOTH
+// days with its original Start/End preserved (not clipped).
+func TestAssignEventsToBuckets_OvernightEventAppearsInBothDays(t *testing.T) {
+	loc := time.UTC
+	monday := time.Date(2026, 4, 20, 0, 0, 0, 0, loc)
+	days := buildWeekBuckets(monday)
+
+	evtStart := time.Date(2026, 4, 20, 22, 0, 0, 0, loc)
+	evtEnd := time.Date(2026, 4, 21, 2, 0, 0, 0, loc)
+	evt := AgendaEvent{
+		ID:    "e1",
+		Title: "Overnight",
+		Start: evtStart,
+		End:   evtEnd,
+	}
+
+	assignEventsToBuckets([]AgendaEvent{evt}, &days, loc)
+
+	if len(days[0].Events) != 1 {
+		t.Errorf("Monday (days[0]): want 1 event, got %d", len(days[0].Events))
+	}
+	if len(days[1].Events) != 1 {
+		t.Errorf("Tuesday (days[1]): want 1 event, got %d", len(days[1].Events))
+	}
+
+	// Original Start/End must be preserved (not clipped to day boundary).
+	for _, dayName := range []string{"Monday", "Tuesday"} {
+		var events []AgendaEvent
+		switch dayName {
+		case "Monday":
+			events = days[0].Events
+		case "Tuesday":
+			events = days[1].Events
+		}
+		if len(events) == 0 {
+			continue
+		}
+		e := events[0]
+		if !e.Start.Equal(evtStart) {
+			t.Errorf("%s: Start clipped: want %v, got %v", dayName, evtStart, e.Start)
+		}
+		if !e.End.Equal(evtEnd) {
+			t.Errorf("%s: End clipped: want %v, got %v", dayName, evtEnd, e.End)
+		}
+	}
+
+	// Wednesday and beyond must be empty.
+	for i := 2; i < 7; i++ {
+		if len(days[i].Events) != 0 {
+			t.Errorf("days[%d]: want 0 events, got %d", i, len(days[i].Events))
+		}
+	}
+}
+
+// TestAssignEventsToBuckets_AllDayEventInCorrectDay verifies that an all-day
+// event stored as UTC midnight appears in the correct local day for a host
+// west of UTC (America/Los_Angeles).
+func TestAssignEventsToBuckets_AllDayEventInCorrectDay(t *testing.T) {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Skip("America/Los_Angeles not available:", err)
+	}
+
+	// Monday 2026-04-20 00:00 local
+	monday := time.Date(2026, 4, 20, 0, 0, 0, 0, loc)
+	days := buildWeekBuckets(monday)
+
+	// Tuesday 2026-04-21 all-day event, stored as UTC midnight (as providers do).
+	// In LA (UTC-8) this UTC midnight is actually Monday April 20 evening;
+	// without the fix it would be bucketed into Monday.
+	evtStart := time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC) // "2026-04-21" UTC midnight
+	evtEnd := time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)
+	evt := AgendaEvent{
+		ID:       "e1",
+		Title:    "Tuesday All-Day",
+		Start:    evtStart,
+		End:      evtEnd,
+		IsAllDay: true,
+	}
+
+	assignEventsToBuckets([]AgendaEvent{evt}, &days, loc)
+
+	if len(days[0].Events) != 0 {
+		t.Errorf("Monday (days[0]): want 0 events (UTC-midnight mis-bucketing fix), got %d", len(days[0].Events))
+	}
+	if len(days[1].Events) != 1 {
+		t.Errorf("Tuesday (days[1]): want 1 event, got %d", len(days[1].Events))
+	}
+}

--- a/plans/prd.json
+++ b/plans/prd.json
@@ -34,7 +34,7 @@
         "Build succeeds"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "Unlike LanesByCalendar (one lane per calendar), FlatLane overlays all calendars into a single lane. Overflow fields are used by the template to render small arrow indicators at the strip edge (PRD §5.2, §7.3)."
     },
     {
@@ -49,7 +49,7 @@
         "Build succeeds"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": "These fields enable the .strip-overflow arrow indicator in the template. The day strip from PR1 doesn't need overflow arrows (single-day window) but the fields won't break it."
     },
     {
@@ -65,7 +65,7 @@
         "Build succeeds"
       ],
       "priority": 4,
-      "passes": false,
+      "passes": true,
       "notes": "The shared window ensures all 7 day rows have identical column alignment so hour labels at the top apply to every row."
     },
     {
@@ -86,7 +86,7 @@
         "Tests pass"
       ],
       "priority": 5,
-      "passes": false,
+      "passes": true,
       "notes": "Add tests to internal/services/agenda_strip_test.go (FlatLane, ComputeSharedWindow) and internal/services/agenda_test.go (GetWeek assignment)."
     },
     {
@@ -104,7 +104,7 @@
         "Build succeeds"
       ],
       "priority": 6,
-      "passes": false,
+      "passes": true,
       "notes": "FullDateFormatted and EventCount are used by the selected-day detail header (see mock line 100: 'Friday, April 17 · 8 events'). Events are unclipped originals for the detail list."
     },
     {

--- a/plans/prd.json
+++ b/plans/prd.json
@@ -17,7 +17,7 @@
         "Build succeeds"
       ],
       "priority": 1,
-      "passes": false,
+      "passes": true,
       "notes": "IMPORTANT: Events are NOT clipped to day boundaries here. Clipping happens only in FlatLane (US-002) for strip rendering. The detail list uses original event times so overnight events show their full duration. See PRD §9 table: 'Full duration in the list.'"
     },
     {

--- a/plans/prd.json
+++ b/plans/prd.json
@@ -125,7 +125,7 @@
         "Build succeeds"
       ],
       "priority": 7,
-      "passes": false,
+      "passes": true,
       "notes": "Reference mock: docs/agenda-mocks/meetwhen_week_hybrid_5_plus_1.html. The selected row uses grid 90px+1fr, background highlight, and 2px left border."
     },
     {
@@ -145,7 +145,7 @@
         "Build succeeds"
       ],
       "priority": 8,
-      "passes": false,
+      "passes": true,
       "notes": "Accesses .Data because it's called via {{template \"week_strip.html\" .}} from the page template where . is PageData. Rows are <button role='tab'> for keyboard accessibility (Tab/Enter/Space to switch days). Mock reference: docs/agenda-mocks/meetwhen_week_hybrid_5_plus_1.html"
     },
     {
@@ -161,7 +161,7 @@
         "Build succeeds"
       ],
       "priority": 9,
-      "passes": false,
+      "passes": true,
       "notes": "Reuses day_detail.html from PR1 via dict helper to construct the expected data shape. This avoids duplicating the event list markup. The detail header is rendered once (not per-day) and updated by JS when the active day changes (US-009). dict template func already exists (added in PR1). NOTE: The week mock shows a denser table-style detail (with header row) vs PR1's simpler card-style list. PR2 accepts the PR1 detail styling for now — a week-specific detail refinement (table layout matching the mock) is deferred to a follow-up."
     },
     {
@@ -179,7 +179,7 @@
         "Build succeeds"
       ],
       "priority": 10,
-      "passes": false,
+      "passes": true,
       "notes": "~25 lines of vanilla JS. No HTMX needed for intra-week switching — the data is already in the DOM. Each row stores its full date and event count in data attributes for the header update."
     },
     {
@@ -198,7 +198,7 @@
         "Build succeeds"
       ],
       "priority": 11,
-      "passes": false,
+      "passes": true,
       "notes": "The ?week= param enables direct linking to a specific week (e.g. /dashboard/agenda?view=week&week=2026-04-13). PRD §6 specifies this route shape."
     },
     {
@@ -213,7 +213,7 @@
         "Build succeeds"
       ],
       "priority": 12,
-      "passes": false,
+      "passes": true,
       "notes": "This replaces the old list-based week view with the strip visualization. Calendar legend is inside week_strip.html (matching mock layout where legend is inside the strip card)."
     }
   ]

--- a/progress.md
+++ b/progress.md
@@ -1825,3 +1825,21 @@ The following features from the requirements document are already fully implemen
   - DST-safe bucket boundaries: always use `monday.AddDate(0, 0, i+1)` not `dayStart.Add(24*time.Hour)` for day bucket edges
   - All-day events stored as UTC midnight by providers; for bucket overlap checks, re-interpret UTC date as local midnight using `time.Date(y, m, d, 0, 0, 0, 0, loc)`
 ----
+
+## 2026-04-25 - US-002/002b/003/004/005/006/007/008/009/010/011 (PR2) - Full week view implementation
+- **US-002/002b**: Added `FlatLane` function and `OverflowLeft`/`OverflowRight` fields to `StripBlock`. Updated `LanesByCalendar` to set overflow fields. `FlatLane` overlays all calendars into one lane; overflow set when original event extents exceed the window.
+- **US-003**: Added `ComputeSharedWindow([7]DayEvents)` — same adaptive 09:00–18:00±30min logic as `ComputeVisibleWindow` but across all 7 days.
+- **US-004**: Tests in `agenda_test.go` (extracted `assignEventsToBuckets` helper for direct testing without repo mocks) and `agenda_strip_test.go` (FlatLane, overflow, ComputeSharedWindow, shared-window+FlatLane integration).
+- **US-005**: `WeekDayView` struct and `BuildWeekDayViews` with formatted date strings, FlatLane blocks, IsToday/IsActive logic.
+- **US-006**: CSS for `.week-strip-container`, `.week-strip-row`, `.week-strip-row--active`, `.week-strip-row--today`, `.week-day-detail`, `.week-detail-header`, `.strip-overflow`.
+- **US-007**: `templates/partials/week_strip.html` with `role="tablist"`, 7 `<button role="tab">` rows, shared hour-label header, overflow indicators, calendar legend inside the card.
+- **US-008/009**: Pre-rendered 7 day panels in `dashboard_agenda.html`, detail header, 28-line vanilla JS day-switching with keyboard Arrow Up/Down + Enter/Space.
+- **US-010**: Handler updated — parses `?week=YYYY-MM-DD` (re-interprets UTC date as local midnight for `GetWeek`), calls `GetWeek`+`ComputeSharedWindow`+`BuildWeekDayViews`. Removed `AgendaDayGroup` type and `groupEventsByDay` function.
+- **US-011**: Week view template branch replaced with `week_strip.html` partial + detail panels + JS.
+- Files changed: `internal/services/agenda.go`, `internal/services/agenda_strip.go`, `internal/services/agenda_test.go`, `internal/services/agenda_strip_test.go`, `internal/handlers/dashboard.go`, `static/css/style.css`, `templates/partials/week_strip.html`, `templates/pages/dashboard_agenda.html`
+- **Learnings for future iterations:**
+  - Testing Go code that calls through `*repository.Repositories` (concrete struct, not interface): extract the pure business logic into a package-level helper function that can be tested directly — no mocks needed.
+  - `time.Parse("2006-01-02", s)` returns midnight UTC. When passing to a service that uses `.In(loc)`, pre-convert: `utcY, utcMo, utcD := parsed.UTC().Date(); t = time.Date(utcY, utcMo, utcD, 0, 0, 0, 0, loc)`. The handler (US-010) is the right place for this conversion, not inside `GetWeek`.
+  - `plans/` is in `.gitignore` — always use `git add -f plans/prd.json` when committing PRD updates.
+  - `{{template "day_detail.html" (dict "Events" $day.Events)}}` pattern works well for passing a named subset of data to a partial that expects a flat struct.
+----

--- a/progress.md
+++ b/progress.md
@@ -1821,4 +1821,7 @@ The following features from the requirements document are already fully implemen
   - `range over int` (e.g., `for i := range 7`) is the modernize-preferred pattern in this codebase
   - Events are intentionally NOT clipped here — clipping happens later in FlatLane (US-002) only for strip rendering
   - `GetAgendaEventsWithCalendars` accepts a `*models.Host` that can be used for timezone in the future
+  - **Critical timezone pattern**: `GetWeek` uses `weekStart.In(loc)` to read local calendar date. Callers passing a date-only UTC parse (`time.Parse("2006-01-02", s)`) MUST pre-convert: `utcY, utcMo, utcD := parsed.UTC().Date(); weekStart = time.Date(utcY, utcMo, utcD, 0, 0, 0, 0, loc)`. Do NOT use `.UTC().Date()` inside `GetWeek` — it breaks east-of-UTC hosts (e.g. JST 2026-04-20 00:00 → UTC April 19 → wrong week).
+  - DST-safe bucket boundaries: always use `monday.AddDate(0, 0, i+1)` not `dayStart.Add(24*time.Hour)` for day bucket edges
+  - All-day events stored as UTC midnight by providers; for bucket overlap checks, re-interpret UTC date as local midnight using `time.Date(y, m, d, 0, 0, 0, 0, loc)`
 ----

--- a/progress.md
+++ b/progress.md
@@ -1810,3 +1810,15 @@ The following features from the requirements document are already fully implemen
   - When features are built as part of earlier stories, check all acceptance criteria before assuming more work is needed
   - The contact backfill pattern (check-then-populate on first access) is a lazy initialization approach
 ----
+
+## 2026-04-25 - US-001 (PR2) - Add GetWeek method to AgendaService
+- Added `DayEvents` struct (DayStart, DayEnd, Events) and `WeekView` struct (Calendars, Days [7]DayEvents, WeekStart, HostTZ) to `internal/services/agenda.go`
+- Added `GetWeek(ctx, hostID, weekStart)` method: loads host+calendars once, calls AssignColors once, fetches full Mon 00:00–next Mon 00:00 window in one call
+- Events assigned to every day they touch (Start < dayEnd AND End > dayStart) without clipping; each day's events sorted by start time
+- Files changed:
+  - `internal/services/agenda.go`
+- **Learnings for future iterations:**
+  - `range over int` (e.g., `for i := range 7`) is the modernize-preferred pattern in this codebase
+  - Events are intentionally NOT clipped here — clipping happens later in FlatLane (US-002) only for strip rendering
+  - `GetAgendaEventsWithCalendars` accepts a `*models.Host` that can be used for timezone in the future
+----

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4871,6 +4871,112 @@ body.modal-open {
 }
 
 /* ============================================
+   Week Strip
+   ============================================ */
+
+.week-strip-container {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: 16px;
+}
+
+.week-strip-row {
+    display: grid;
+    grid-template-columns: 90px 1fr;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+    cursor: pointer;
+    background: none;
+    border: none;
+    width: 100%;
+    text-align: left;
+    border-radius: var(--radius-sm);
+}
+
+.week-strip-row:hover {
+    background: var(--gray-100);
+}
+
+.week-strip-row--active {
+    background: var(--gray-100);
+    border-left: 2px solid var(--accent);
+    padding-left: 6px;
+}
+
+.week-strip-row--today .week-strip-day-label::after {
+    content: " today";
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    vertical-align: middle;
+    margin-left: 2px;
+}
+
+.week-strip-day-label {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--gray-700);
+    white-space: nowrap;
+}
+
+.week-day-details {
+    margin-top: 12px;
+}
+
+.week-day-detail {
+    display: none;
+}
+
+.week-day-detail--active {
+    display: block;
+}
+
+.week-detail-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 10px 0 8px;
+    border-bottom: 1px solid var(--gray-100);
+    margin-bottom: 8px;
+}
+
+.week-detail-header-title {
+    font-weight: 600;
+    font-size: 1rem;
+    color: var(--gray-900);
+}
+
+.week-detail-header-hint {
+    font-size: 0.8rem;
+    color: var(--gray-500);
+}
+
+.strip-overflow {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.5rem;
+    color: var(--gray-500);
+    pointer-events: none;
+}
+
+.strip-overflow--left {
+    left: 0;
+}
+
+.strip-overflow--right {
+    right: 0;
+}
+
+/* ============================================
    Color Swatch Picker
    ============================================ */
 

--- a/templates/pages/dashboard_agenda.html
+++ b/templates/pages/dashboard_agenda.html
@@ -8,7 +8,7 @@
         <h1 class="page-title">Agenda</h1>
         <p class="page-subtitle">
             {{if eq .Data.View "week"}}
-            Week of {{formatDate (index .Data.DayGroups 0).Date}}
+            {{if .Data.WeekDays}}Week of {{(index .Data.WeekDays 0).DateFormatted}}{{else}}This Week{{end}}
             {{else}}
             {{formatDate .Data.Today}}
             {{end}}
@@ -22,41 +22,83 @@
 </div>
 
 {{if eq .Data.View "week"}}
-<!-- Week view - events grouped by day -->
-<div class="agenda-week">
-    {{range .Data.DayGroups}}
-    <div class="day-group">
-        <div class="day-header">
-            <span class="day-name">{{.Date.Weekday}}</span>
-            <span class="day-date">{{formatDate .Date}}</span>
-        </div>
-        {{if .Events}}
-        <div class="events-list">
-            {{range .Events}}
-            <div class="event-item {{if .IsAllDay}}all-day{{end}}" style="{{if .CalendarColor}}border-left: 3px solid {{.CalendarColor}};{{end}}">
-                <div class="event-time">
-                    {{if .IsAllDay}}
-                    <span class="all-day-badge">All Day</span>
-                    {{else}}
-                    <div class="event-time-range">{{formatTime .Start}} - {{formatTime .End}}</div>
-                    <div class="event-duration">{{duration .Start .End}}</div>
-                    {{end}}
-                </div>
-                <div class="event-content">
-                    <div class="event-title">{{if .Title}}{{.Title}}{{else}}(No title){{end}}</div>
-                    <div class="event-details">
-                        <span class="event-calendar" {{if .CalendarColor}}style="color: {{.CalendarColor}};"{{end}}>{{.CalendarName}}</span>
-                    </div>
-                </div>
-            </div>
-            {{end}}
-        </div>
-        {{else}}
-        <div class="no-events">No events scheduled</div>
-        {{end}}
+<!-- Week view - visual strip with shared time axis -->
+{{template "week_strip.html" .}}
+
+{{/* Detail header — updated by JS when a day row is clicked */}}
+{{range .Data.WeekDays}}{{if .IsActive}}
+<div class="week-detail-header" id="week-detail-header">
+    <span class="week-detail-header-title" id="week-detail-title">{{.FullDateFormatted}} &middot; {{.EventCount}} event{{if ne .EventCount 1}}s{{end}}</span>
+    <span class="week-detail-header-hint">click any day above to switch</span>
+</div>
+{{end}}{{end}}
+
+<!-- Pre-rendered day detail panels — all 7 in DOM, only active visible -->
+<div class="week-day-details">
+    {{range $i, $day := .Data.WeekDays}}
+    <div class="week-day-detail{{if $day.IsActive}} week-day-detail--active{{end}}"
+         id="week-day-panel-{{$i}}"
+         data-day-index="{{$i}}"
+         role="tabpanel"
+         aria-labelledby="week-tab-{{$i}}">
+        {{template "day_detail.html" (dict "Events" $day.Events)}}
     </div>
     {{end}}
 </div>
+
+<script>
+(function() {
+    var strip = document.querySelector('[role="tablist"]');
+    if (!strip) return;
+
+    function activate(idx) {
+        var tabs = strip.querySelectorAll('[role="tab"]');
+        var panels = document.querySelectorAll('.week-day-detail');
+        var header = document.getElementById('week-detail-title');
+
+        tabs.forEach(function(t) {
+            var active = parseInt(t.dataset.dayIndex, 10) === idx;
+            t.classList.toggle('week-strip-row--active', active);
+            t.setAttribute('aria-selected', active ? 'true' : 'false');
+        });
+
+        panels.forEach(function(p) {
+            var active = parseInt(p.dataset.dayIndex, 10) === idx;
+            p.classList.toggle('week-day-detail--active', active);
+        });
+
+        var activeTab = strip.querySelector('[data-day-index="' + idx + '"]');
+        if (activeTab && header) {
+            var count = parseInt(activeTab.dataset.eventCount, 10) || 0;
+            header.textContent = activeTab.dataset.fullDate + ' \u00b7 ' + count + ' event' + (count === 1 ? '' : 's');
+        }
+    }
+
+    strip.addEventListener('click', function(e) {
+        var btn = e.target.closest('[role="tab"]');
+        if (!btn) return;
+        activate(parseInt(btn.dataset.dayIndex, 10));
+    });
+
+    strip.addEventListener('keydown', function(e) {
+        var btn = e.target.closest('[role="tab"]');
+        if (!btn) return;
+        var tabs = Array.from(strip.querySelectorAll('[role="tab"]'));
+        var idx = tabs.indexOf(btn);
+        if (e.key === 'ArrowDown' && idx < tabs.length - 1) {
+            tabs[idx + 1].focus();
+            e.preventDefault();
+        } else if (e.key === 'ArrowUp' && idx > 0) {
+            tabs[idx - 1].focus();
+            e.preventDefault();
+        } else if (e.key === 'Enter' || e.key === ' ') {
+            activate(parseInt(btn.dataset.dayIndex, 10));
+            e.preventDefault();
+        }
+    });
+})();
+</script>
+
 {{else}}
 <!-- Today view - Calendar Strip + Event List -->
 {{template "calendar_legend.html" .}}

--- a/templates/partials/week_strip.html
+++ b/templates/partials/week_strip.html
@@ -1,0 +1,59 @@
+{{define "week_strip.html"}}
+<div class="week-strip-container">
+    {{if .Data.WeekDays}}
+    {{/* Shared hour-label header — same grid columns as each row */}}
+    <div class="strip-header" style="display: grid; grid-template-columns: 90px 1fr; margin-bottom: 4px;">
+        <div></div>
+        <div style="position: relative; height: 20px;">
+            {{range .Data.HourLabels}}
+            <span style="position: absolute; left: {{.LeftPct}}%; font-size: 0.65rem; color: var(--gray-500); transform: translateX(-50%);">{{.Label}}</span>
+            {{end}}
+        </div>
+    </div>
+
+    {{/* 7 day rows — each a tab button */}}
+    <div role="tablist">
+        {{range $i, $day := .Data.WeekDays}}
+        <button
+            class="week-strip-row{{if $day.IsActive}} week-strip-row--active{{end}}{{if $day.IsToday}} week-strip-row--today{{end}}"
+            role="tab"
+            aria-selected="{{if $day.IsActive}}true{{else}}false{{end}}"
+            aria-controls="week-day-panel-{{$i}}"
+            id="week-tab-{{$i}}"
+            data-day-index="{{$i}}"
+            data-full-date="{{$day.FullDateFormatted}}"
+            data-event-count="{{$day.EventCount}}"
+            type="button">
+            <span class="week-strip-day-label">{{$day.DayName}}<br><span style="font-size:0.75rem;color:var(--gray-500)">{{$day.DateFormatted}}</span></span>
+            <div class="strip-lane" style="position: relative;">
+                {{range $day.Blocks}}
+                <div class="strip-block"
+                     style="left: {{printf "%.4f" .LeftPct}}%; width: {{printf "%.4f" .WidthPct}}%; background: {{.Color}};"
+                     title="{{.Title}}">
+                    {{if .OverflowLeft}}<span class="strip-overflow strip-overflow--left">&#9664;</span>{{end}}
+                    {{if .OverflowRight}}<span class="strip-overflow strip-overflow--right">&#9654;</span>{{end}}
+                    {{if gt .WidthPct 8.0}}
+                    <span style="font-size:0.6rem;color:#fff;padding:0 2px;overflow:hidden;white-space:nowrap;display:block;text-overflow:ellipsis;">{{.Title}}</span>
+                    {{end}}
+                </div>
+                {{end}}
+            </div>
+        </button>
+        {{end}}
+    </div>
+
+    {{/* Calendar legend inside the strip card */}}
+    <ul class="calendar-legend" style="margin-top: 12px;">
+        {{range .Data.Calendars}}
+        <li style="display: flex; align-items: center; gap: 4px;">
+            <span class="calendar-dot" style="background-color: {{.Color}};"></span>
+            <span>{{.Name}}</span>
+        </li>
+        {{end}}
+    </ul>
+
+    {{else}}
+    <p style="color: var(--gray-500); font-size: 0.875rem;">No calendars connected.</p>
+    {{end}}
+</div>
+{{end}}

--- a/templates/partials/week_strip.html
+++ b/templates/partials/week_strip.html
@@ -1,6 +1,6 @@
 {{define "week_strip.html"}}
 <div class="week-strip-container">
-    {{if .Data.WeekDays}}
+    {{if .Data.Calendars}}
     {{/* Shared hour-label header — same grid columns as each row */}}
     <div class="strip-header" style="display: grid; grid-template-columns: 90px 1fr; margin-bottom: 4px;">
         <div></div>


### PR DESCRIPTION
## Summary

- 7-day week strip visualization with shared time axis and per-calendar colored blocks
- Client-side day switching (pre-rendered, no server round-trip)
- Single provider call for the entire week (no N+1 fetches)
- Full ARIA tab semantics with keyboard navigation

## Details

### Service layer
- `AgendaService.GetWeek`: loads calendars once, fetches events in a single provider call, assigns events to day buckets with original Start/End preserved (no clipping)
- `FlatLane`: produces single-lane strip blocks for the compact week view, clips to window boundary, sets OverflowLeft/OverflowRight flags
- `ComputeSharedWindow`: computes a unified time axis across all 7 days using time-of-day semantics
- `BuildWeekDayViews`: bridge struct with FullDateFormatted, EventCount, IsToday, IsActive

### Frontend
- `week_strip.html`: 7 stacked day rows with shared hour labels, `role="tablist"` with `<button role="tab">`, overflow indicators, calendar legend inside the strip card
- Pre-rendered 7 day-detail blocks reusing `day_detail.html` via `dict` helper
- Vanilla JS day switching (~50 lines): click, Arrow Up/Down, Enter/Space
- Detail header updates with full date and event count on day switch
- `?week=YYYY-MM-DD` query param for direct week navigation (falls back to current week on malformed input)

### Cleanup
- Removed `groupEventsByDay` and `AgendaDayGroup` from handler (replaced by service layer)

## Test plan

- [x] Navigate to /dashboard/agenda?view=week — week strip shows 7 day rows with colored blocks
- [ ] Hour labels at top align across all 7 day rows
- [x] Click a day row — detail panel switches instantly, no page reload
- [ ] Keyboard: Tab to strip, Arrow Up/Down to move between days, Enter/Space to select
- [ ] Today's row shows "today" badge and is initially selected
- [ ] Detail panel shows full event times (overnight events not clipped in the list)
- [ ] Overflow arrows appear on blocks extending beyond the shared time window
- [ ] Calendar legend visible inside the strip card
- [ ] Navigate to ?view=week&week=2026-04-13 — shows that specific week
- [ ] Today tab still works correctly
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)