### PR TITLE
Fix remaining raw UTC time displays across all templates

### DIFF
--- a/internal/handlers/template_test.go
+++ b/internal/handlers/template_test.go
@@ -45,6 +45,15 @@ func TestBookingStatusTemplate_SignupCTA(t *testing.T) {
 				"formatDateTime": func(t models.SQLiteTime) string {
 					return "2026-01-29 10:00 AM"
 				},
+				"formatDateInTZ": func(t models.SQLiteTime, tz string) string {
+					return "Wednesday, January 29, 2026"
+				},
+				"formatTimeInTZ": func(t models.SQLiteTime, tz string) string {
+					return "10:00 AM"
+				},
+				"tzAbbrev": func(tz string, t models.SQLiteTime) string {
+					return "UTC"
+				},
 			}).ParseFiles("../../templates/pages/booking_status.html")
 			if err != nil {
 				t.Fatalf("Failed to parse template: %v", err)
@@ -153,6 +162,9 @@ func TestBookingStatusTemplate_SignupCTA_ButtonStyle(t *testing.T) {
 		"formatDateTime": func(t models.SQLiteTime) string {
 			return "2026-01-29 10:00 AM"
 		},
+		"formatDateInTZ": func(t models.SQLiteTime, tz string) string { return "Wednesday, January 29, 2026" },
+		"formatTimeInTZ": func(t models.SQLiteTime, tz string) string { return "10:00 AM" },
+		"tzAbbrev":       func(tz string, t models.SQLiteTime) string { return "UTC" },
 	}).ParseFiles("../../templates/pages/booking_status.html")
 	if err != nil {
 		t.Fatalf("Failed to parse template: %v", err)
@@ -212,6 +224,10 @@ func TestBookingStatusTemplate_NoSignupCTA_WhenCancelled(t *testing.T) {
 	tmpl, err := template.New("booking_status.html").Funcs(template.FuncMap{
 		"formatDateTime": func(t models.SQLiteTime) string {
 			return "2026-01-29 10:00 AM"
+		},
+		"formatDateInTZ": func(t models.SQLiteTime, tz string) string { return "Wednesday, January 29, 2026" },
+		"formatTimeInTZ": func(t models.SQLiteTime, tz string) string { return "10:00 AM" },
+		"tzAbbrev": func(tz string, t models.SQLiteTime) string { return "UTC"
 		},
 	}).ParseFiles("../../templates/pages/booking_status.html")
 	if err != nil {

--- a/templates/pages/booking_status.html
+++ b/templates/pages/booking_status.html
@@ -112,7 +112,10 @@
                     </div>
                     <div class="detail-content">
                         <span class="detail-label">Date & Time</span>
-                        <span class="detail-value">{{formatDateTime .Data.Booking.StartTime}}</span>
+                        <span class="detail-value">
+                            {{formatDateInTZ .Data.Booking.StartTime .Data.Booking.InviteeTimezone}}<br>
+                            {{formatTimeInTZ .Data.Booking.StartTime .Data.Booking.InviteeTimezone}} - {{formatTimeInTZ .Data.Booking.EndTime .Data.Booking.InviteeTimezone}} {{tzAbbrev .Data.Booking.InviteeTimezone .Data.Booking.StartTime}}
+                        </span>
                     </div>
                 </div>
 

--- a/templates/pages/dashboard_home.html
+++ b/templates/pages/dashboard_home.html
@@ -58,7 +58,12 @@
             <tbody>
                 {{range .Data.Bookings}}
                 <tr>
-                    <td>{{formatDateTime .StartTime}}</td>
+                    <td>
+                        <div class="datetime-cell">
+                            <span class="date">{{formatDateInTZ .StartTime $.Host.Timezone}}</span>
+                            <span class="time">{{formatTimeInTZ .StartTime $.Host.Timezone}} - {{formatTimeInTZ .EndTime $.Host.Timezone}} {{tzAbbrev $.Host.Timezone .StartTime}}</span>
+                        </div>
+                    </td>
                     <td>
                         <div class="guest-info">
                             <span class="guest-name">{{.InviteeName}}</span>

--- a/templates/pages/reschedule.html
+++ b/templates/pages/reschedule.html
@@ -46,7 +46,7 @@
                             <line x1="8" y1="2" x2="8" y2="6"/>
                             <line x1="3" y1="10" x2="21" y2="10"/>
                         </svg>
-                        {{formatDateTime .Data.Booking.StartTime}}
+                        {{formatDateInTZ .Data.Booking.StartTime .Data.Booking.InviteeTimezone}}, {{formatTimeInTZ .Data.Booking.StartTime .Data.Booking.InviteeTimezone}} {{tzAbbrev .Data.Booking.InviteeTimezone .Data.Booking.StartTime}}
                     </div>
                     <div class="meta-row">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18">
@@ -147,7 +147,7 @@
                             </div>
                             <div class="summary-row old-time">
                                 <span class="summary-label">Previous Time</span>
-                                <span class="summary-value">{{formatDateTime .Data.Booking.StartTime}}</span>
+                                <span class="summary-value">{{formatDateInTZ .Data.Booking.StartTime .Data.Booking.InviteeTimezone}}, {{formatTimeInTZ .Data.Booking.StartTime .Data.Booking.InviteeTimezone}} {{tzAbbrev .Data.Booking.InviteeTimezone .Data.Booking.StartTime}}</span>
                             </div>
                             <div class="summary-row new-time">
                                 <span class="summary-label">New Time</span>

--- a/templates/partials/booking_details_partial.html
+++ b/templates/partials/booking_details_partial.html
@@ -195,7 +195,7 @@
             <div class="booking-detail-section booking-meta">
                 <div class="booking-detail-row">
                     <span class="label">Created</span>
-                    <span class="value text-muted">{{formatDateTime .Booking.CreatedAt}}</span>
+                    <span class="value text-muted">{{formatDateInTZ .Booking.CreatedAt .HostTimezone}}, {{formatTimeInTZ .Booking.CreatedAt .HostTimezone}}</span>
                 </div>
             </div>
             {{else}}


### PR DESCRIPTION
## Summary

Completes the timezone display fix started in PR #32. Four templates were still showing booking times in raw UTC.

## Changes

| Template | Before | After |
|----------|--------|-------|
| Dashboard home (recent bookings) | `2:00 PM` (raw UTC) | `4:00 PM - 4:30 PM CEST` (host TZ) |
| Booking status (public confirmation) | Raw UTC | Invitee's timezone |
| Reschedule page (current time, 2 places) | Raw UTC | Invitee's timezone |
| Booking detail modal (CreatedAt) | Raw UTC | Host timezone |

Also includes `scripts/fix_stale_reschedules.sql` — a data fix for 8 bookings that were rescheduled before the BookingRepository.Update method included start_time/end_time columns.

## Test plan

- [ ] Dashboard home shows booking times in host timezone
- [ ] Public booking confirmation page shows times in invitee timezone
- [ ] Reschedule page shows current booking time in invitee timezone
- [ ] Booking detail modal shows CreatedAt in host timezone
- [ ] \`go test ./...\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)