### PR TITLE
fix: responsive mobile layout for calendar color picker

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5088,6 +5088,72 @@ body.modal-open {
         width: 100%;
         max-width: none;
     }
+
+    /* Sub-calendar rows: stack vertically on mobile */
+    .sub-calendar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--gray-100);
+    }
+
+    .sub-calendar:last-child {
+        border-bottom: none;
+    }
+
+    .sub-calendar-info {
+        gap: 8px;
+        flex-wrap: wrap;
+    }
+
+    /* Controls row: full width, allow wrapping */
+    .sub-calendar-controls {
+        width: 100%;
+        flex-wrap: wrap;
+        gap: 8px;
+        align-items: center;
+    }
+
+    /* Color swatches on mobile: hide name labels, scroll horizontally */
+    .color-swatches {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        padding-bottom: 4px;
+        gap: 10px;
+        /* prevent the fieldset form from stretching full width and forcing wrap */
+        max-width: calc(100vw - 48px);
+    }
+
+    .swatch-name {
+        display: none;
+    }
+
+    .swatch-circle {
+        width: 22px;
+        height: 22px;
+        display: block;
+        flex-shrink: 0;
+    }
+
+    .color-swatch {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        flex-shrink: 0;
+    }
+
+    /* Keep color swatch form inline */
+    .sub-calendar-controls form {
+        flex-shrink: 0;
+    }
+
+    /* Calendar header: wrap on very narrow screens */
+    .calendar-card .calendar-header {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
 }
 
 /* Small mobile */

--- a/templates/partials/color_swatch_fieldset.html
+++ b/templates/partials/color_swatch_fieldset.html
@@ -3,7 +3,7 @@
      connection-level color route for backwards compatibility, but can be
      overridden so per-sub-calendar pickers post to /sub/{id}/color. */}}
 <form hx-post="{{if .FormAction}}{{.FormAction}}{{else}}/dashboard/calendars/{{.CalendarID}}/color{{end}}" hx-swap="outerHTML">
-    <fieldset class="color-swatches" style="border: none; padding: 0;">
+    <fieldset class="color-swatches" style="border: none; padding: 0; margin: 0;">
         {{range .Palette}}
         <label class="color-swatch">
             <input type="radio"


### PR DESCRIPTION
## Summary

- Sub-calendar rows now stack vertically on mobile instead of overflowing horizontally
- Color swatches display as a horizontally-scrollable row of circles on mobile (names hidden) — fixes the broken vertical list seen in the screenshot
- Controls row (Set Default button, poll toggle) wraps cleanly below the color picker
- Calendar header wraps gracefully on narrow screens
- Slightly larger touch targets for swatch circles (22px vs 16px)

## Test plan

- [ ] View the Calendars settings page on a mobile-width browser (≤768px)
- [ ] Verify color swatches appear as a single scrollable horizontal row of circles
- [ ] Verify the sub-calendar name/info row appears above the controls row
- [ ] Verify Set Default button and poll toggle are accessible and not overlapping
- [ ] Verify desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)