### PR TITLE
fix(zoom): disconnect 404, expired-token visibility, booking edit (#39, #38, #33)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -116,6 +116,7 @@ func main() {
 	dashboard.HandleFunc("POST /dashboard/calendars/connect/google", h.Dashboard.ConnectGoogle)
 	dashboard.HandleFunc("POST /dashboard/calendars/connect/caldav", h.Dashboard.ConnectCalDAV)
 	dashboard.HandleFunc("POST /dashboard/calendars/{id}/disconnect", h.Dashboard.DisconnectCalendar)
+	dashboard.HandleFunc("POST /dashboard/conferencing/{provider}/disconnect", h.Dashboard.DisconnectConferencing)
 	dashboard.HandleFunc("POST /dashboard/calendars/{id}/default", h.Dashboard.SetDefaultCalendar)
 	dashboard.HandleFunc("POST /dashboard/calendars/{id}/refresh", h.Dashboard.RefreshCalendarSync)
 	dashboard.HandleFunc("POST /dashboard/calendars/{id}/color", h.Dashboard.UpdateCalendarColor)
@@ -141,6 +142,8 @@ func main() {
 	// Bookings management
 	dashboard.HandleFunc("GET /dashboard/bookings", h.Dashboard.Bookings)
 	dashboard.HandleFunc("GET /dashboard/bookings/{id}/details", h.Dashboard.BookingDetails)
+	dashboard.HandleFunc("GET /dashboard/bookings/{id}/edit", h.Dashboard.EditBookingForm)
+	dashboard.HandleFunc("POST /dashboard/bookings/{id}/edit", h.Dashboard.UpdateBooking)
 
 	// Agenda view
 	dashboard.HandleFunc("GET /dashboard/agenda", h.Dashboard.Agenda)

--- a/internal/handlers/dashboard.go
+++ b/internal/handlers/dashboard.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -173,6 +175,36 @@ func (h *DashboardHandler) DisconnectCalendar(w http.ResponseWriter, r *http.Req
 	_ = h.handlers.services.Calendar.DisconnectCalendar(r.Context(), host.Host.ID, calendarID)
 
 	h.handlers.redirect(w, r, "/dashboard/calendars")
+}
+
+// DisconnectConferencing removes a conferencing provider connection (currently Zoom).
+func (h *DashboardHandler) DisconnectConferencing(w http.ResponseWriter, r *http.Request) {
+	host := middleware.GetHost(r.Context())
+	if host == nil {
+		h.handlers.redirect(w, r, "/auth/login")
+		return
+	}
+
+	provider := models.ConferencingProvider(r.PathValue("provider"))
+	switch provider {
+	case models.ConferencingProviderZoom:
+		// allowed
+	default:
+		h.handlers.redirect(w, r, "/dashboard/calendars?error=unsupported_provider")
+		return
+	}
+
+	if err := h.handlers.services.Conferencing.DisconnectProvider(r.Context(), host.Host.ID, provider); err != nil {
+		log.Printf("[CONFERENCING] disconnect failed for host=%s provider=%s: %v", host.Host.ID, provider, err)
+		h.handlers.redirect(w, r, "/dashboard/calendars?error=disconnect_failed")
+		return
+	}
+
+	hostID := host.Host.ID
+	h.handlers.services.AuditLog.Log(r.Context(), host.Tenant.ID, &hostID, "conferencing.disconnected", "conferencing", "",
+		models.JSONMap{"provider": string(provider)}, r.RemoteAddr)
+
+	h.handlers.redirect(w, r, "/dashboard/calendars?success=zoom_disconnected")
 }
 
 // RefreshCalendarSync manually triggers a sync check for a connection. It both
@@ -1464,6 +1496,113 @@ func (h *DashboardHandler) BookingDetails(w http.ResponseWriter, r *http.Request
 		"Template":     template,
 		"HostTimezone": host.Host.Timezone,
 	})
+}
+
+// EditBookingForm renders the booking-edit form as a partial. Modal-based;
+// loaded via HTMX from the booking-details modal.
+func (h *DashboardHandler) EditBookingForm(w http.ResponseWriter, r *http.Request) {
+	host := middleware.GetHost(r.Context())
+	if host == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	bookingID := r.PathValue("id")
+	booking, err := h.handlers.services.Booking.GetBooking(r.Context(), bookingID)
+	if err != nil || booking == nil || booking.HostID != host.Host.ID {
+		http.Error(w, "Booking not found", http.StatusNotFound)
+		return
+	}
+	if booking.Status != models.BookingStatusConfirmed {
+		http.Error(w, "Only confirmed bookings can be edited", http.StatusBadRequest)
+		return
+	}
+
+	template, _ := h.handlers.services.Template.GetTemplate(r.Context(), host.Host.ID, booking.TemplateID)
+
+	hostNotes := ""
+	if booking.Answers != nil {
+		if v, ok := booking.Answers["host_notes"].(string); ok {
+			hostNotes = v
+		}
+	}
+
+	h.handlers.renderPartial(w, "booking_edit_partial.html", map[string]interface{}{
+		"Booking":                booking,
+		"Template":               template,
+		"HostTimezone":           host.Host.Timezone,
+		"HostNotes":              hostNotes,
+		"AdditionalGuestsString": strings.Join(booking.AdditionalGuests, "\n"),
+		"FormError":              r.URL.Query().Get("error"),
+	})
+}
+
+// UpdateBooking applies host edits, redirects back to the bookings list with
+// a flash on success or the edit form with an error on failure.
+func (h *DashboardHandler) UpdateBooking(w http.ResponseWriter, r *http.Request) {
+	host := middleware.GetHost(r.Context())
+	if host == nil {
+		h.handlers.redirect(w, r, "/auth/login")
+		return
+	}
+
+	bookingID := r.PathValue("id")
+	if err := r.ParseForm(); err != nil {
+		h.handlers.redirect(w, r, "/dashboard/bookings/"+bookingID+"/edit?error=invalid_form")
+		return
+	}
+
+	notes := r.FormValue("host_notes")
+	guestsRaw := r.FormValue("additional_guests")
+	guests := splitGuestsField(guestsRaw)
+	regenerate := r.FormValue("regenerate_link") == "1"
+
+	input := services.UpdateBookingInput{
+		HostID:                   host.Host.ID,
+		TenantID:                 host.Tenant.ID,
+		BookingID:                bookingID,
+		HostNotes:                &notes,
+		AdditionalGuests:         &guests,
+		RegenerateConferenceLink: regenerate,
+	}
+
+	if v := r.FormValue("conference_link"); r.Form.Has("conference_link") && !regenerate {
+		v = strings.TrimSpace(v)
+		input.ConferenceLink = &v
+	}
+
+	_, _, err := h.handlers.services.Booking.UpdateBooking(r.Context(), input)
+	if err != nil {
+		log.Printf("[BOOKING] update failed for %s: %v", bookingID, err)
+		flag := "update_failed"
+		if errors.Is(err, services.ErrConferencingReauthRequired) {
+			flag = "reauth_required"
+		}
+		h.handlers.redirect(w, r, "/dashboard/bookings/"+bookingID+"/edit?error="+flag)
+		return
+	}
+
+	h.handlers.redirect(w, r, "/dashboard/bookings?success=updated")
+}
+
+// splitGuestsField parses the textarea contents (one guest per line, optionally
+// comma-separated) into a clean slice. Final filtering/dedupe happens in the
+// service via normalizeGuestList.
+func splitGuestsField(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	// Replace commas with newlines so users can paste either format.
+	raw = strings.ReplaceAll(raw, ",", "\n")
+	lines := strings.Split(raw, "\n")
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
 }
 
 // AuditLogs renders the audit log viewer page (admin only)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
@@ -186,14 +187,21 @@ const (
 
 // ConferencingConnection represents a connected conferencing provider
 type ConferencingConnection struct {
-	ID           string               `json:"id" db:"id"`
-	HostID       string               `json:"host_id" db:"host_id"`
-	Provider     ConferencingProvider `json:"provider" db:"provider"`
-	AccessToken  string               `json:"-" db:"access_token"`
-	RefreshToken string               `json:"-" db:"refresh_token"`
-	TokenExpiry  *SQLiteTime          `json:"-" db:"token_expiry"`
-	CreatedAt    SQLiteTime           `json:"created_at" db:"created_at"`
-	UpdatedAt    SQLiteTime           `json:"updated_at" db:"updated_at"`
+	ID               string               `json:"id" db:"id"`
+	HostID           string               `json:"host_id" db:"host_id"`
+	Provider         ConferencingProvider `json:"provider" db:"provider"`
+	AccessToken      string               `json:"-" db:"access_token"`
+	RefreshToken     string               `json:"-" db:"refresh_token"`
+	TokenExpiry      *SQLiteTime          `json:"-" db:"token_expiry"`
+	LastRefreshError sql.NullString       `json:"-" db:"last_refresh_error"`
+	CreatedAt        SQLiteTime           `json:"created_at" db:"created_at"`
+	UpdatedAt        SQLiteTime           `json:"updated_at" db:"updated_at"`
+}
+
+// NeedsReauth reports whether this connection has had a non-recoverable token
+// failure and the host must reconnect via the OAuth flow.
+func (c *ConferencingConnection) NeedsReauth() bool {
+	return c.LastRefreshError.Valid && c.LastRefreshError.String != ""
 }
 
 // MeetingTemplate represents a bookable meeting type

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -548,19 +548,19 @@ type ConferencingRepository struct {
 func (r *ConferencingRepository) Create(ctx context.Context, conn *models.ConferencingConnection) error {
 	query := q(r.driver, `
 		INSERT INTO conferencing_connections (id, host_id, provider, access_token,
-			refresh_token, token_expiry, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			refresh_token, token_expiry, last_refresh_error, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`)
 	_, err := r.db.ExecContext(ctx, query,
 		conn.ID, conn.HostID, conn.Provider, conn.AccessToken,
-		conn.RefreshToken, conn.TokenExpiry, conn.CreatedAt, conn.UpdatedAt)
+		conn.RefreshToken, conn.TokenExpiry, conn.LastRefreshError, conn.CreatedAt, conn.UpdatedAt)
 	return err
 }
 
 func (r *ConferencingRepository) GetByHostID(ctx context.Context, hostID string) ([]*models.ConferencingConnection, error) {
 	query := q(r.driver, `
 		SELECT id, host_id, provider, access_token, refresh_token, token_expiry,
-		       created_at, updated_at
+		       last_refresh_error, created_at, updated_at
 		FROM conferencing_connections WHERE host_id = $1
 	`)
 	rows, err := r.db.QueryContext(ctx, query, hostID)
@@ -578,7 +578,7 @@ func (r *ConferencingRepository) GetByHostID(ctx context.Context, hostID string)
 		conn := &models.ConferencingConnection{}
 		err := rows.Scan(
 			&conn.ID, &conn.HostID, &conn.Provider, &conn.AccessToken,
-			&conn.RefreshToken, &conn.TokenExpiry, &conn.CreatedAt, &conn.UpdatedAt)
+			&conn.RefreshToken, &conn.TokenExpiry, &conn.LastRefreshError, &conn.CreatedAt, &conn.UpdatedAt)
 		if err != nil {
 			return nil, err
 		}
@@ -591,12 +591,12 @@ func (r *ConferencingRepository) GetByHostAndProvider(ctx context.Context, hostI
 	conn := &models.ConferencingConnection{}
 	query := q(r.driver, `
 		SELECT id, host_id, provider, access_token, refresh_token, token_expiry,
-		       created_at, updated_at
+		       last_refresh_error, created_at, updated_at
 		FROM conferencing_connections WHERE host_id = $1 AND provider = $2
 	`)
 	err := r.db.QueryRowContext(ctx, query, hostID, provider).Scan(
 		&conn.ID, &conn.HostID, &conn.Provider, &conn.AccessToken,
-		&conn.RefreshToken, &conn.TokenExpiry, &conn.CreatedAt, &conn.UpdatedAt)
+		&conn.RefreshToken, &conn.TokenExpiry, &conn.LastRefreshError, &conn.CreatedAt, &conn.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -606,11 +606,11 @@ func (r *ConferencingRepository) GetByHostAndProvider(ctx context.Context, hostI
 func (r *ConferencingRepository) Update(ctx context.Context, conn *models.ConferencingConnection) error {
 	query := q(r.driver, `
 		UPDATE conferencing_connections
-		SET access_token = $1, refresh_token = $2, token_expiry = $3
-		WHERE id = $4
+		SET access_token = $1, refresh_token = $2, token_expiry = $3, last_refresh_error = $4
+		WHERE id = $5
 	`)
 	_, err := r.db.ExecContext(ctx, query,
-		conn.AccessToken, conn.RefreshToken, conn.TokenExpiry, conn.ID)
+		conn.AccessToken, conn.RefreshToken, conn.TokenExpiry, conn.LastRefreshError, conn.ID)
 	return err
 }
 
@@ -948,13 +948,15 @@ func (r *BookingRepository) Update(ctx context.Context, booking *models.Booking)
 		UPDATE bookings
 		SET status = $1, conference_link = $2, calendar_event_id = $3,
 		    cancelled_by = $4, cancel_reason = $5, reminder_sent = $6, is_archived = $7,
-		    start_time = $8, end_time = $9, duration = $10, updated_at = $11
-		WHERE id = $12
+		    start_time = $8, end_time = $9, duration = $10,
+		    additional_guests = $11, answers = $12, updated_at = $13
+		WHERE id = $14
 	`)
 	_, err := r.db.ExecContext(ctx, query,
 		booking.Status, booking.ConferenceLink, booking.CalendarEventID,
 		booking.CancelledBy, booking.CancelReason, booking.ReminderSent,
 		booking.IsArchived, booking.StartTime, booking.EndTime, booking.Duration,
+		booking.AdditionalGuests, booking.Answers,
 		booking.UpdatedAt, booking.ID)
 	return err
 }
@@ -1616,5 +1618,14 @@ func (r *BookingCalendarEventRepository) GetByBookingID(ctx context.Context, boo
 func (r *BookingCalendarEventRepository) DeleteByBookingID(ctx context.Context, bookingID string) error {
 	query := q(r.driver, `DELETE FROM booking_calendar_events WHERE booking_id = $1`)
 	_, err := r.db.ExecContext(ctx, query, bookingID)
+	return err
+}
+
+// Update changes the calendar event ID for a booking_calendar_events row.
+// Used after a CalDAV "update" (which is implemented as delete + create) so
+// the new event ID is persisted.
+func (r *BookingCalendarEventRepository) Update(ctx context.Context, e *models.BookingCalendarEvent) error {
+	query := q(r.driver, `UPDATE booking_calendar_events SET event_id = $1, calendar_id = $2 WHERE id = $3`)
+	_, err := r.db.ExecContext(ctx, query, e.EventID, e.CalendarID, e.ID)
 	return err
 }

--- a/internal/services/booking.go
+++ b/internal/services/booking.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -348,6 +349,218 @@ func (s *BookingService) deleteAllCalendarEvents(ctx context.Context, booking *m
 			}
 		}
 	}
+}
+
+// UpdateBookingInput captures the host-editable fields of a confirmed booking.
+// Each pointer is nil if that field is not being changed; non-nil means
+// "replace with this value". RegenerateConferenceLink is a separate one-shot
+// action: when true the existing link is replaced by a freshly created one
+// using the template's configured provider (used to recover after a Zoom
+// reauth — see issue #38).
+type UpdateBookingInput struct {
+	HostID                   string
+	TenantID                 string
+	BookingID                string
+	HostNotes                *string
+	AdditionalGuests         *[]string
+	ConferenceLink           *string
+	RegenerateConferenceLink bool
+}
+
+// UpdateBooking applies host edits to an existing confirmed booking and
+// distributes an updated calendar invitation. Returns the (possibly modified)
+// list of fields that actually changed so the audit log and email reflect the
+// real diff. ErrConferencingReauthRequired is returned untouched if the host
+// asked to regenerate a link but the conferencing token is dead — the caller
+// should surface a "reconnect first" message.
+func (s *BookingService) UpdateBooking(ctx context.Context, input UpdateBookingInput) (*BookingWithDetails, []string, error) {
+	booking, err := s.repos.Booking.GetByID(ctx, input.BookingID)
+	if err != nil || booking == nil || booking.HostID != input.HostID {
+		return nil, nil, ErrBookingNotFound
+	}
+	if booking.Status != models.BookingStatusConfirmed {
+		return nil, nil, errors.New("only confirmed bookings can be edited")
+	}
+
+	template, err := s.repos.Template.GetByID(ctx, booking.TemplateID)
+	if err != nil || template == nil {
+		return nil, nil, ErrTemplateNotFound
+	}
+	host, _ := s.repos.Host.GetByID(ctx, booking.HostID)
+	tenant, _ := s.repos.Tenant.GetByID(ctx, input.TenantID)
+	details := &BookingWithDetails{
+		Booking:  booking,
+		Template: template,
+		Host:     host,
+		Tenant:   tenant,
+	}
+
+	var changed []string
+
+	if input.HostNotes != nil {
+		if booking.Answers == nil {
+			booking.Answers = models.JSONMap{}
+		}
+		old, _ := booking.Answers["host_notes"].(string)
+		if old != *input.HostNotes {
+			if *input.HostNotes == "" {
+				delete(booking.Answers, "host_notes")
+			} else {
+				booking.Answers["host_notes"] = *input.HostNotes
+			}
+			changed = append(changed, "notes")
+		}
+	}
+
+	if input.AdditionalGuests != nil {
+		oldList := append([]string(nil), booking.AdditionalGuests...)
+		newList := normalizeGuestList(*input.AdditionalGuests)
+		if !sameStringSlice(oldList, newList) {
+			booking.AdditionalGuests = newList
+			changed = append(changed, "additional guests")
+		}
+	}
+
+	if input.RegenerateConferenceLink {
+		// Clear existing link and re-create using the template's provider.
+		// On reauth-required, we surface the typed error to the handler so the
+		// UI can prompt the host to reconnect — booking state is left intact.
+		link, err := s.conferencing.CreateMeeting(ctx, details)
+		if err != nil {
+			if errors.Is(err, ErrConferencingReauthRequired) {
+				return details, nil, err
+			}
+			return details, nil, fmt.Errorf("regenerate conference link: %w", err)
+		}
+		if link != "" && link != booking.ConferenceLink {
+			booking.ConferenceLink = link
+			changed = append(changed, "conference link")
+			// Successful regeneration clears any prior _conference_error marker.
+			if booking.Answers != nil {
+				delete(booking.Answers, "_conference_error")
+			}
+		}
+	} else if input.ConferenceLink != nil && *input.ConferenceLink != booking.ConferenceLink {
+		booking.ConferenceLink = *input.ConferenceLink
+		changed = append(changed, "conference link")
+		if booking.Answers != nil {
+			delete(booking.Answers, "_conference_error")
+		}
+	}
+
+	if len(changed) == 0 {
+		return details, nil, nil
+	}
+
+	booking.UpdatedAt = models.Now()
+	if err := s.repos.Booking.Update(ctx, booking); err != nil {
+		return details, nil, err
+	}
+
+	// Push the changes to the host's calendar so attendees get an updated
+	// invitation. We try the legacy single-host event first, then fall through
+	// to any pooled-host events so all calendars stay in sync.
+	s.updateAllCalendarEvents(ctx, details, template)
+
+	if tenant != nil && host != nil {
+		s.email.SendBookingUpdated(ctx, details, changed)
+	}
+
+	hostID := input.HostID
+	tenantID := input.TenantID
+	s.auditLog.Log(ctx, tenantID, &hostID, "booking.updated", "booking", booking.ID, models.JSONMap{
+		"changed_fields": changed,
+	}, "")
+
+	return details, changed, nil
+}
+
+// updateAllCalendarEvents patches the calendar event(s) for a booking after a
+// host edit. Mirrors deleteAllCalendarEvents: pooled-host events live in
+// booking_calendar_events; legacy single-host bookings have only
+// booking.CalendarEventID with template.CalendarID as the calendar.
+func (s *BookingService) updateAllCalendarEvents(ctx context.Context, details *BookingWithDetails, template *models.MeetingTemplate) {
+	calEvents, err := s.repos.BookingCalendarEvent.GetByBookingID(ctx, details.Booking.ID)
+	if err != nil {
+		log.Printf("[BOOKING] Error loading calendar events for booking %s: %v", details.Booking.ID, err)
+	}
+
+	if len(calEvents) > 0 {
+		for _, ce := range calEvents {
+			perHost := &BookingWithDetails{
+				Booking:  details.Booking,
+				Template: template,
+				Host:     details.Host,
+				Tenant:   details.Tenant,
+			}
+			// Force the per-host event ID through CalendarEventID so the
+			// PATCH targets the correct event for this calendar.
+			savedID := perHost.Booking.CalendarEventID
+			perHost.Booking.CalendarEventID = ce.EventID
+			newID, err := s.calendar.UpdateEvent(ctx, perHost, ce.CalendarID)
+			perHost.Booking.CalendarEventID = savedID
+			if err != nil {
+				log.Printf("[BOOKING] Error updating calendar event %s for host %s: %v", ce.EventID, ce.HostID, err)
+				continue
+			}
+			if newID != "" && newID != ce.EventID {
+				// CalDAV path replaced the event; persist the new ID.
+				ce.EventID = newID
+				if err := s.repos.BookingCalendarEvent.Update(ctx, ce); err != nil {
+					log.Printf("[BOOKING] Error updating booking_calendar_events record: %v", err)
+				}
+			}
+		}
+		return
+	}
+
+	if details.Booking.CalendarEventID != "" && template.CalendarID != "" {
+		newID, err := s.calendar.UpdateEvent(ctx, details, template.CalendarID)
+		if err != nil {
+			log.Printf("[BOOKING] Error updating legacy calendar event: %v", err)
+			return
+		}
+		if newID != "" && newID != details.Booking.CalendarEventID {
+			details.Booking.CalendarEventID = newID
+			// Persist the swapped ID so reschedule/cancel still find the event.
+			if err := s.repos.Booking.Update(ctx, details.Booking); err != nil {
+				log.Printf("[BOOKING] Error persisting new event ID: %v", err)
+			}
+		}
+	}
+}
+
+func normalizeGuestList(in []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, g := range in {
+		g = strings.TrimSpace(g)
+		if g == "" {
+			continue
+		}
+		if !strings.Contains(g, "@") {
+			continue
+		}
+		key := strings.ToLower(g)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, g)
+	}
+	return out
+}
+
+func sameStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // CancelBookingByToken cancels a booking using the public token (for invitee cancellation)
@@ -740,6 +953,7 @@ func (s *BookingService) processConfirmedBooking(ctx context.Context, details *B
 		link, err := s.conferencing.CreateMeeting(ctx, details)
 		if err != nil {
 			log.Printf("[BOOKING] Error creating conference link: %v", err)
+			s.recordConferencingFailure(ctx, details, err)
 		} else if link != "" {
 			log.Printf("[BOOKING] Conference link created: %s", link)
 			details.Booking.ConferenceLink = link
@@ -860,5 +1074,37 @@ func (s *BookingService) createPooledHostCalendarEvents(ctx context.Context, det
 				details.Booking.CalendarEventID = eventID
 			}
 		}
+	}
+}
+
+// recordConferencingFailure marks a booking with a conferencing-link failure so
+// the dashboard surfaces it (similar to calendar sync failures), and notifies
+// the host. The booking itself is still confirmed — issue #38 explicitly asks
+// us to "create a booking regardless".
+func (s *BookingService) recordConferencingFailure(ctx context.Context, details *BookingWithDetails, cause error) {
+	if details.Booking.Answers == nil {
+		details.Booking.Answers = models.JSONMap{}
+	}
+	reason := "transient"
+	if errors.Is(cause, ErrConferencingReauthRequired) {
+		reason = "reauth_required"
+	}
+	details.Booking.Answers["_conference_error"] = map[string]any{
+		"provider": string(details.Template.LocationType),
+		"reason":   reason,
+		"message":  cause.Error(),
+		"at":       time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Load host (may not be populated on details) for the notification email.
+	host := details.Host
+	if host == nil {
+		h, hErr := s.repos.Host.GetByID(ctx, details.Booking.HostID)
+		if hErr == nil {
+			host = h
+		}
+	}
+	if host != nil {
+		s.email.SendConferencingFailed(ctx, host, string(details.Template.LocationType), reason, cause.Error())
 	}
 }

--- a/internal/services/booking_edit_test.go
+++ b/internal/services/booking_edit_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeGuestList(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"trims and dedupes case-insensitively",
+			[]string{"  alice@example.com ", "ALICE@example.com", "bob@example.com"},
+			[]string{"alice@example.com", "bob@example.com"},
+		},
+		{"drops empty and non-email lines",
+			[]string{"", "   ", "not-an-email", "carol@example.com"},
+			[]string{"carol@example.com"},
+		},
+		{"preserves first-seen casing",
+			[]string{"Dave@Example.com", "dave@example.com"},
+			[]string{"Dave@Example.com"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeGuestList(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("normalizeGuestList(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSameStringSlice(t *testing.T) {
+	cases := []struct {
+		a, b []string
+		want bool
+	}{
+		{nil, nil, true},
+		{[]string{}, nil, true},
+		{[]string{"a"}, []string{"a"}, true},
+		{[]string{"a", "b"}, []string{"a", "b"}, true},
+		{[]string{"a", "b"}, []string{"b", "a"}, false}, // order matters — guests are an ordered list
+		{[]string{"a"}, []string{"a", "b"}, false},
+	}
+	for i, tc := range cases {
+		if got := sameStringSlice(tc.a, tc.b); got != tc.want {
+			t.Errorf("case %d: sameStringSlice(%v, %v) = %v, want %v", i, tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/internal/services/calendar.go
+++ b/internal/services/calendar.go
@@ -607,6 +607,56 @@ func (s *CalendarService) CreateEventForHost(ctx context.Context, details *Booki
 	return "", nil
 }
 
+// UpdateEvent updates an existing calendar event for a booking. If the booking
+// has no recorded event ID (e.g. event creation previously failed), falls back
+// to CreateEventForHost so reconnect-then-edit produces a fresh event.
+//
+// For Google: issues a PATCH so existing attendees keep their RSVP state and
+// get a single "event updated" invitation. For CalDAV: replaces the event via
+// delete + create (CalDAV does not have a clean PATCH primitive in this
+// codebase; the resulting iCal carries the new state to all attendees).
+func (s *CalendarService) UpdateEvent(ctx context.Context, details *BookingWithDetails, providerCalendarID string) (string, error) {
+	if details.Booking.CalendarEventID == "" {
+		return s.CreateEventForHost(ctx, details, providerCalendarID)
+	}
+	if providerCalendarID == "" {
+		return details.Booking.CalendarEventID, nil
+	}
+
+	pc, err := s.repos.ProviderCalendar.GetByID(ctx, providerCalendarID)
+	if err != nil {
+		return "", err
+	}
+	if pc == nil {
+		return "", ErrCalendarNotFound
+	}
+	conn, err := s.repos.Calendar.GetByID(ctx, pc.ConnectionID)
+	if err != nil || conn == nil {
+		return "", ErrCalendarNotFound
+	}
+
+	view := *conn
+	switch conn.Provider {
+	case models.CalendarProviderGoogle:
+		view.CalendarID = pc.ProviderCalendarID
+		return s.updateGoogleEvent(ctx, &view, details)
+	case models.CalendarProviderCalDAV, models.CalendarProviderICloud:
+		if pc.ProviderCalendarID != "" {
+			view.CalDAVURL = pc.ProviderCalendarID
+		}
+		// CalDAV: replace via delete + create.
+		if err := s.deleteCalDAVEvent(ctx, &view, details.Booking.CalendarEventID); err != nil {
+			log.Printf("[CALENDAR] CalDAV delete during update failed: %v", err)
+		}
+		newID, err := s.createCalDAVEvent(ctx, &view, details)
+		if err != nil {
+			return "", err
+		}
+		return newID, nil
+	}
+	return details.Booking.CalendarEventID, nil
+}
+
 // DeleteEvent deletes a calendar event from a provider calendar.
 func (s *CalendarService) DeleteEvent(ctx context.Context, hostID, providerCalendarID, eventID string) error {
 	pc, err := s.repos.ProviderCalendar.GetByID(ctx, providerCalendarID)
@@ -1051,6 +1101,80 @@ func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.Cal
 	}
 
 	return result.ID, nil
+}
+
+// updateGoogleEvent PATCHes an existing Google Calendar event. The patch body
+// only includes mutable fields (description, location, attendees) — title and
+// time are left unchanged so this method composes safely with reschedule
+// (which deletes and recreates rather than patches).
+func (s *CalendarService) updateGoogleEvent(ctx context.Context, cal *models.CalendarConnection, details *BookingWithDetails) (string, error) {
+	if err := s.refreshGoogleToken(cal); err != nil {
+		return "", err
+	}
+
+	attendees := []map[string]string{
+		{"email": details.Booking.InviteeEmail},
+	}
+	for _, guest := range details.Booking.AdditionalGuests {
+		if strings.Contains(guest, "@") && len(strings.Split(guest, "@")[0]) > 0 && len(strings.Split(guest, "@")[1]) > 1 {
+			attendees = append(attendees, map[string]string{"email": guest})
+		}
+	}
+
+	description := details.Template.Description
+	if details.Booking.Answers != nil {
+		if agenda, ok := details.Booking.Answers["agenda"].(string); ok && agenda != "" {
+			if description != "" {
+				description += "\n\n"
+			}
+			description += "Agenda:\n" + agenda
+		}
+		if notes, ok := details.Booking.Answers["host_notes"].(string); ok && notes != "" {
+			if description != "" {
+				description += "\n\n"
+			}
+			description += "Notes from host:\n" + notes
+		}
+	}
+	rescheduleURL := fmt.Sprintf("%s/m/%s/%s/%s/reschedule/%s",
+		s.cfg.Server.BaseURL, details.Tenant.Slug, details.Host.Slug, details.Template.Slug, details.Booking.ID)
+	if description != "" {
+		description += "\n\n"
+	}
+	description += "Reschedule this meeting:\n" + rescheduleURL
+
+	patch := map[string]interface{}{
+		"description": description,
+		"attendees":   attendees,
+	}
+	if details.Booking.ConferenceLink != "" {
+		patch["location"] = details.Booking.ConferenceLink
+	}
+
+	body, _ := json.Marshal(patch)
+	patchURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events/%s?sendUpdates=all",
+		url.PathEscape(cal.CalendarID), url.PathEscape(details.Booking.CalendarEventID))
+
+	req, _ := http.NewRequest("PATCH", patchURL, strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+cal.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("Error closing response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("failed to update event: %s", string(respBody))
+	}
+
+	return details.Booking.CalendarEventID, nil
 }
 
 func (s *CalendarService) deleteGoogleEvent(ctx context.Context, cal *models.CalendarConnection, eventID string) error {

--- a/internal/services/conferencing.go
+++ b/internal/services/conferencing.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -15,6 +17,13 @@ import (
 	"github.com/meet-when/meet-when/internal/models"
 	"github.com/meet-when/meet-when/internal/repository"
 )
+
+// ErrConferencingReauthRequired indicates that the host's conferencing OAuth
+// token cannot be refreshed (revoked, expired beyond grace, or invalid) and the
+// host must reconnect via the OAuth flow. Callers in the booking path treat
+// this differently from transient errors: the booking still confirms but the
+// host is notified and the connection is flagged for reconnect.
+var ErrConferencingReauthRequired = errors.New("conferencing reauth required")
 
 // ConferencingService handles video conferencing operations
 type ConferencingService struct {
@@ -62,6 +71,8 @@ func (s *ConferencingService) ConnectZoom(ctx context.Context, hostID, authCode,
 		existing.AccessToken = tokens.AccessToken
 		existing.RefreshToken = tokens.RefreshToken
 		existing.TokenExpiry = &expiry
+		// A successful reconnect clears any prior reauth state.
+		existing.LastRefreshError = sql.NullString{}
 		if err := s.repos.Conferencing.Update(ctx, existing); err != nil {
 			return nil, err
 		}
@@ -152,21 +163,50 @@ func (s *ConferencingService) exchangeZoomAuthCode(code, redirectURI string) (*z
 	return &tokens, nil
 }
 
-func (s *ConferencingService) refreshZoomToken(conn *models.ConferencingConnection) error {
-	// Only skip refresh if we have a valid, unexpired token with >5 min remaining
+// zoomTokenError is the OAuth-style error body Zoom returns on token endpoint
+// failures (e.g. {"reason":"Invalid Token!","error":"invalid_grant"}).
+type zoomTokenError struct {
+	Error  string `json:"error"`
+	Reason string `json:"reason"`
+}
+
+// isPermanentTokenError reports whether the Zoom OAuth error code indicates a
+// non-recoverable refresh-token failure (revoked / expired beyond grace /
+// invalid). Transient HTTP/network errors and 5xx responses are NOT permanent.
+func isPermanentTokenError(code string) bool {
+	switch code {
+	case "invalid_grant", "invalid_request", "invalid_client", "unauthorized_client", "unsupported_grant_type":
+		return true
+	}
+	return false
+}
+
+func (s *ConferencingService) refreshZoomToken(ctx context.Context, conn *models.ConferencingConnection) error {
+	// Skip refresh if we already have a valid, unexpired token with >5 min remaining.
 	if conn.TokenExpiry != nil && time.Now().Before(conn.TokenExpiry.Add(-5*time.Minute)) {
 		return nil
 	}
 
+	// If we previously flagged this connection as needing reauth and the token
+	// is also expired, fail fast — refresh would only fail again. The host must
+	// reconnect via OAuth.
+	if conn.NeedsReauth() {
+		return ErrConferencingReauthRequired
+	}
+
 	data := fmt.Sprintf("refresh_token=%s&grant_type=refresh_token", conn.RefreshToken)
 
-	req, _ := http.NewRequest("POST", "https://zoom.us/oauth/token", strings.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://zoom.us/oauth/token", strings.NewReader(data))
+	if err != nil {
+		return err
+	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(s.cfg.OAuth.Zoom.ClientID, s.cfg.OAuth.Zoom.ClientSecret)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		// Network/transport error — transient, do not flag connection.
+		return fmt.Errorf("zoom token refresh transport error: %w", err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -175,7 +215,23 @@ func (s *ConferencingService) refreshZoomToken(conn *models.ConferencingConnecti
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to refresh token")
+		body, _ := io.ReadAll(resp.Body)
+		var oauthErr zoomTokenError
+		_ = json.Unmarshal(body, &oauthErr)
+		// 4xx with a known permanent error code → require reauth.
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 && isPermanentTokenError(oauthErr.Error) {
+			conn.LastRefreshError = sql.NullString{
+				String: fmt.Sprintf("%s: %s", oauthErr.Error, oauthErr.Reason),
+				Valid:  true,
+			}
+			if upErr := s.repos.Conferencing.Update(ctx, conn); upErr != nil {
+				log.Printf("[ZOOM] failed to persist reauth flag for conn=%s: %v", conn.ID, upErr)
+			}
+			log.Printf("[ZOOM] reauth required for host=%s: %s (%s)", conn.HostID, oauthErr.Error, oauthErr.Reason)
+			return ErrConferencingReauthRequired
+		}
+		// Other 4xx (rate limit-ish) and 5xx → transient.
+		return fmt.Errorf("zoom token refresh failed (status=%d): %s", resp.StatusCode, string(body))
 	}
 
 	var tokens zoomTokenResponse
@@ -189,17 +245,18 @@ func (s *ConferencingService) refreshZoomToken(conn *models.ConferencingConnecti
 	}
 	expiry := models.NewSQLiteTime(time.Now().Add(time.Duration(tokens.ExpiresIn) * time.Second))
 	conn.TokenExpiry = &expiry
+	conn.LastRefreshError = sql.NullString{} // clear on success
 
-	return s.repos.Conferencing.Update(context.Background(), conn)
+	return s.repos.Conferencing.Update(ctx, conn)
 }
 
 func (s *ConferencingService) createZoomMeeting(ctx context.Context, details *BookingWithDetails) (string, error) {
 	conn, err := s.repos.Conferencing.GetByHostAndProvider(ctx, details.Booking.HostID, models.ConferencingProviderZoom)
 	if err != nil || conn == nil {
-		return "", fmt.Errorf("zoom not connected")
+		return "", ErrConferencingReauthRequired
 	}
 
-	if err := s.refreshZoomToken(conn); err != nil {
+	if err := s.refreshZoomToken(ctx, conn); err != nil {
 		return "", err
 	}
 

--- a/internal/services/conferencing_token_test.go
+++ b/internal/services/conferencing_token_test.go
@@ -1,0 +1,26 @@
+package services
+
+import "testing"
+
+func TestIsPermanentTokenError(t *testing.T) {
+	cases := []struct {
+		code string
+		want bool
+	}{
+		{"invalid_grant", true},        // refresh token revoked or expired beyond grace
+		{"invalid_request", true},      // malformed / missing param
+		{"invalid_client", true},       // wrong client credentials
+		{"unauthorized_client", true},  // client not allowed this grant
+		{"unsupported_grant_type", true},
+
+		{"", false},
+		{"server_error", false},        // 5xx-ish, retry later
+		{"temporarily_unavailable", false},
+		{"rate_limited", false},
+	}
+	for _, tc := range cases {
+		if got := isPermanentTokenError(tc.code); got != tc.want {
+			t.Errorf("isPermanentTokenError(%q) = %v, want %v", tc.code, got, tc.want)
+		}
+	}
+}

--- a/internal/services/email.go
+++ b/internal/services/email.go
@@ -491,6 +491,91 @@ Meet When`,
 	}()
 }
 
+// SendBookingUpdated notifies the invitee (and any additional guests) that the
+// host has edited the booking. Time is unchanged — that path is
+// SendBookingRescheduled. The summary names the changed fields so the
+// recipient knows what to look at.
+func (s *EmailService) SendBookingUpdated(ctx context.Context, details *BookingWithDetails, changedFields []string) {
+	subject := fmt.Sprintf("Updated: %s with %s", details.Template.Name, details.Host.Name)
+
+	inviteeLoc, _ := time.LoadLocation(details.Booking.InviteeTimezone)
+	if inviteeLoc == nil {
+		inviteeLoc = time.UTC
+	}
+	timeFormatted := details.Booking.StartTime.In(inviteeLoc).Format("Monday, January 2, 2006 at 3:04 PM MST")
+
+	location := "To be determined"
+	if details.Template.LocationType == models.ConferencingProviderPhone {
+		if details.Template.CustomLocation != "" {
+			location = "Call " + details.Template.CustomLocation
+		}
+	} else if details.Booking.ConferenceLink != "" {
+		location = details.Booking.ConferenceLink
+	} else if details.Template.CustomLocation != "" {
+		location = details.Template.CustomLocation
+	}
+
+	notes := ""
+	if details.Booking.Answers != nil {
+		if hn, ok := details.Booking.Answers["host_notes"].(string); ok && hn != "" {
+			notes = "\n\nNotes from host:\n" + hn
+		}
+	}
+
+	changes := "the booking"
+	if len(changedFields) > 0 {
+		changes = strings.Join(changedFields, ", ")
+	}
+
+	body := fmt.Sprintf(`Hello %s,
+
+%s has updated %s for your meeting.
+
+Meeting: %s
+With: %s
+When: %s
+Duration: %d minutes
+Location: %s%s
+
+Need to make changes?
+Cancel: %s/booking/%s
+
+Reschedule this meeting:
+%s/m/%s/%s/%s/reschedule/%s
+
+Best regards,
+Meet When`,
+		details.Booking.InviteeName,
+		details.Host.Name,
+		changes,
+		details.Template.Name,
+		details.Host.Name,
+		timeFormatted,
+		details.Booking.Duration,
+		location,
+		notes,
+		s.cfg.Server.BaseURL,
+		details.Booking.Token,
+		s.cfg.Server.BaseURL,
+		details.Tenant.Slug,
+		details.Host.Slug,
+		details.Template.Slug,
+		details.Booking.ID,
+	)
+
+	ics := s.generateICS(details)
+
+	recipients := append([]string{details.Booking.InviteeEmail}, details.Booking.AdditionalGuests...)
+	for _, addr := range recipients {
+		addr := addr
+		go func() {
+			if err := s.sendEmail(addr, subject, body, ics); err != nil {
+				log.Printf("Error sending booking-updated email to %s: %v", addr, err)
+			}
+		}()
+	}
+}
+
 // defaultReminderBody returns the default reminder email body
 func (s *EmailService) defaultReminderBody(data *EmailTemplateData) string {
 	return fmt.Sprintf(`Hello %s,
@@ -753,6 +838,43 @@ func (s *EmailService) sendMailgun(to, subject, body, icsAttachment string) erro
 	// Mailgun API implementation
 	// For MVP, we'll use the SMTP relay which is simpler
 	return s.sendSMTP(to, subject, body, icsAttachment)
+}
+
+// SendConferencingFailed notifies the host that creating a conference link
+// (e.g. a Zoom meeting) failed for a booking — typically because the OAuth
+// token has expired or been revoked. The booking still confirms; the host
+// needs to reconnect (and may use the booking edit flow to regenerate the
+// link once reconnected).
+func (s *EmailService) SendConferencingFailed(ctx context.Context, host *models.Host, provider, reason, errMsg string) {
+	subject := fmt.Sprintf("Action needed: %s link could not be created", provider)
+
+	reconnectHint := ""
+	if reason == "reauth_required" {
+		reconnectHint = fmt.Sprintf("Your %s connection appears to have expired. Reconnect here:\n%s/dashboard/calendars\n\n", provider, s.cfg.Server.BaseURL)
+	}
+
+	body := fmt.Sprintf(`Hello %s,
+
+We could not generate a %s meeting link for a recent booking on your calendar.
+
+%sReason: %s
+
+The booking is still confirmed — the invitee has been notified — but no conference link was attached. After reconnecting %s, you can edit the booking from your dashboard to regenerate the link, which will send an updated invitation to the attendees.
+
+Best regards,
+Meet When`,
+		host.Name,
+		provider,
+		reconnectHint,
+		errMsg,
+		provider,
+	)
+
+	go func() {
+		if err := s.sendEmail(host.Email, subject, body, ""); err != nil {
+			log.Printf("[EMAIL] Error sending conferencing failure notification to %s: %v", host.Email, err)
+		}
+	}()
 }
 
 // SendCalendarSyncFailed notifies the host that their calendar sync has failed

--- a/migrations/013_add_conferencing_last_error.down.sql
+++ b/migrations/013_add_conferencing_last_error.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE conferencing_connections DROP COLUMN last_refresh_error;

--- a/migrations/013_add_conferencing_last_error.up.sql
+++ b/migrations/013_add_conferencing_last_error.up.sql
@@ -1,0 +1,3 @@
+-- Track the most recent token-refresh failure for each conferencing connection.
+-- When non-empty the connection is in a "reauth required" state.
+ALTER TABLE conferencing_connections ADD COLUMN last_refresh_error TEXT;

--- a/migrations/sqlite/013_add_conferencing_last_error.down.sql
+++ b/migrations/sqlite/013_add_conferencing_last_error.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE conferencing_connections DROP COLUMN last_refresh_error;

--- a/migrations/sqlite/013_add_conferencing_last_error.up.sql
+++ b/migrations/sqlite/013_add_conferencing_last_error.up.sql
@@ -1,0 +1,3 @@
+-- Track the most recent token-refresh failure for each conferencing connection.
+-- When non-empty the connection is in a "reauth required" state.
+ALTER TABLE conferencing_connections ADD COLUMN last_refresh_error TEXT;

--- a/templates/pages/dashboard_calendars.html
+++ b/templates/pages/dashboard_calendars.html
@@ -205,8 +205,12 @@
 
     <div class="conferencing-list">
         {{$hasZoom := false}}
+        {{$zoomNeedsReauth := false}}
         {{range .Data.Conferencing}}
-            {{if eq .Provider "zoom"}}{{$hasZoom = true}}{{end}}
+            {{if eq .Provider "zoom"}}
+                {{$hasZoom = true}}
+                {{if .NeedsReauth}}{{$zoomNeedsReauth = true}}{{end}}
+            {{end}}
         {{end}}
 
         <div class="conferencing-card">
@@ -223,15 +227,25 @@
             <div class="conferencing-info">
                 <div class="conferencing-header">
                     <span class="conferencing-name">Zoom</span>
-                    {{if $hasZoom}}
+                    {{if $zoomNeedsReauth}}
+                    <span class="badge badge-warning">Reconnect required</span>
+                    {{else if $hasZoom}}
                     <span class="badge badge-success">Connected</span>
                     {{else}}
                     <span class="badge badge-inactive">Not Connected</span>
                     {{end}}
                 </div>
+                {{if $zoomNeedsReauth}}
+                <p class="conferencing-description">Zoom is unable to refresh tokens for this connection. New bookings on Zoom-typed meeting types will not get a Zoom link until you reconnect.</p>
+                {{end}}
             </div>
             <div class="conferencing-actions">
-                {{if $hasZoom}}
+                {{if $zoomNeedsReauth}}
+                <a href="{{.Data.ZoomAuthURL}}" class="btn-sm btn-primary">Reconnect Zoom</a>
+                <form action="/dashboard/conferencing/zoom/disconnect" method="POST" style="display:inline">
+                    <button type="submit" class="btn-sm btn-danger">Disconnect</button>
+                </form>
+                {{else if $hasZoom}}
                 <form action="/dashboard/conferencing/zoom/disconnect" method="POST">
                     <button type="submit" class="btn-sm btn-danger">Disconnect</button>
                 </form>

--- a/templates/partials/booking_details_partial.html
+++ b/templates/partials/booking_details_partial.html
@@ -205,6 +205,12 @@
             {{end}}
         </div>
         <div class="modal-footer">
+            {{if and .Booking (eq .Booking.Status "confirmed")}}
+            <button type="button" class="btn btn-primary"
+                    hx-get="/dashboard/bookings/{{.Booking.ID}}/edit"
+                    hx-target=".modal-overlay"
+                    hx-swap="outerHTML">Edit</button>
+            {{end}}
             <button type="button" class="btn btn-outline" onclick="closeBookingModal()">Close</button>
         </div>
     </div>

--- a/templates/partials/booking_edit_partial.html
+++ b/templates/partials/booking_edit_partial.html
@@ -1,0 +1,92 @@
+{{define "booking_edit_partial.html"}}
+<div class="modal-overlay" onclick="closeBookingModal(event)">
+    <div class="modal-content" onclick="event.stopPropagation()">
+        <div class="modal-header">
+            <h2>Edit Booking</h2>
+            <button type="button" class="modal-close" onclick="closeBookingModal()" aria-label="Close">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="24" height="24">
+                    <line x1="18" y1="6" x2="6" y2="18"/>
+                    <line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+            </button>
+        </div>
+        <form action="/dashboard/bookings/{{.Booking.ID}}/edit" method="POST">
+            <div class="modal-body">
+                {{if .FormError}}
+                <div class="alert alert-error" style="margin-bottom: 1rem;">
+                    {{if eq .FormError "reauth_required"}}
+                    Could not regenerate the conference link — your conferencing connection needs to be re-authorized. <a href="/dashboard/calendars">Reconnect</a> and try again.
+                    {{else if eq .FormError "update_failed"}}
+                    Sorry, something went wrong saving the changes. Please try again.
+                    {{else}}
+                    {{.FormError}}
+                    {{end}}
+                </div>
+                {{end}}
+
+                <div class="booking-detail-section">
+                    <h3>Meeting</h3>
+                    <div class="booking-detail-row">
+                        <span class="label">Type</span>
+                        <span class="value">{{if .Template}}{{.Template.Name}}{{else}}Unknown{{end}}</span>
+                    </div>
+                    <div class="booking-detail-row">
+                        <span class="label">When</span>
+                        <span class="value">
+                            {{formatDateInTZ .Booking.StartTime .HostTimezone}},
+                            {{formatTimeInTZ .Booking.StartTime .HostTimezone}} - {{formatTimeInTZ .Booking.EndTime .HostTimezone}}
+                            {{tzAbbrev .HostTimezone .Booking.StartTime}}
+                        </span>
+                    </div>
+                    <div class="booking-detail-row">
+                        <span class="label">Guest</span>
+                        <span class="value">{{.Booking.InviteeName}} &lt;{{.Booking.InviteeEmail}}&gt;</span>
+                    </div>
+                </div>
+
+                <div class="booking-detail-section">
+                    <h3>Notes from host</h3>
+                    <p class="text-muted" style="font-size: 0.85em; margin-top: 0;">Visible to attendees in the calendar invitation. Use this to add an agenda or context.</p>
+                    <textarea name="host_notes" rows="4" class="form-control" placeholder="Add a note for the attendees…">{{.HostNotes}}</textarea>
+                </div>
+
+                <div class="booking-detail-section">
+                    <h3>Additional guests</h3>
+                    <p class="text-muted" style="font-size: 0.85em; margin-top: 0;">One email per line. Added guests will receive the updated calendar invitation.</p>
+                    <textarea name="additional_guests" rows="3" class="form-control" placeholder="alice@example.com&#10;bob@example.com">{{.AdditionalGuestsString}}</textarea>
+                </div>
+
+                <div class="booking-detail-section">
+                    <h3>Conference link</h3>
+                    {{if .Booking.ConferenceLink}}
+                    <div class="booking-detail-row">
+                        <span class="label">Current</span>
+                        <a href="{{.Booking.ConferenceLink}}" target="_blank" class="value link">{{.Booking.ConferenceLink}}</a>
+                    </div>
+                    {{else}}
+                    <p class="text-muted" style="font-size: 0.9em;">No conference link is currently attached.</p>
+                    {{end}}
+
+                    {{if or (eq .Template.LocationType "zoom") (eq .Template.LocationType "google_meet")}}
+                    <div class="form-row" style="margin-top: 0.75rem;">
+                        <label style="display: inline-flex; align-items: center; gap: 0.5rem;">
+                            <input type="checkbox" name="regenerate_link" value="1">
+                            Regenerate {{if eq .Template.LocationType "zoom"}}Zoom{{else}}Google Meet{{end}} link
+                        </label>
+                    </div>
+                    {{end}}
+
+                    <div class="form-row" style="margin-top: 0.75rem;">
+                        <label for="conference_link_input" style="display:block; font-size: 0.9em;">Or set a custom link (leave unchanged to keep the current value):</label>
+                        <input type="url" id="conference_link_input" name="conference_link" class="form-control" placeholder="https://…" value="{{.Booking.ConferenceLink}}">
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline" onclick="closeBookingModal()">Cancel</button>
+                <button type="submit" class="btn btn-primary">Save changes</button>
+            </div>
+        </form>
+    </div>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary

Three issues that turned out to be entangled. See plan file for the full reasoning trail.

- **Closes #39** — `POST /dashboard/conferencing/zoom/disconnect` was 404 because the route was never defined, even though the template's disconnect form posts to it.
- **Closes #38** — When a host's Zoom refresh token expired, `processConfirmedBooking` silently confirmed bookings with `conference_link == ""`. The host found out only when the meeting started.
- **Closes #33** — Hosts can now edit a confirmed booking (notes, additional guests, conference link) and have an updated calendar invitation distributed.

#39 unblocks #38 (you couldn't reconnect Zoom without disconnecting first), and #33's "regenerate conference link" is the recovery path for #38d.

## Changes

**#39** — `cmd/server/main.go`, `internal/handlers/dashboard.go`
- New route `POST /dashboard/conferencing/{provider}/disconnect` + `DisconnectConferencing` handler (provider allowlist), reusing the existing unused `ConferencingService.DisconnectProvider`. Writes a `conferencing.disconnected` audit entry.

**#38** — refresh-error classification + visibility
- Migration `013_add_conferencing_last_error` (Postgres + SQLite): nullable `last_refresh_error` on `conferencing_connections`.
- `refreshZoomToken` now uses the passed ctx, classifies Zoom OAuth error codes (`invalid_grant`/`invalid_request`/etc → permanent), persists `last_refresh_error`, and returns the new `ErrConferencingReauthRequired`. Cleared on a successful refresh or reconnect.
- `processConfirmedBooking` records the failure on the booking (`Answers._conference_error`) and notifies the host via the new `SendConferencingFailed` email (mirrors `SendCalendarSyncFailed`). Booking still confirms — the issue explicitly asks for that.
- Dashboard shows a "Reconnect required" badge + reconnect/disconnect buttons when `connection.NeedsReauth()`.

**#33 + #38d** — edit booking
- `BookingService.UpdateBooking` accepting a sparse `UpdateBookingInput` (host notes, additional guests, conference link, regenerate flag). Diffs against current state, persists, patches calendar events via `updateAllCalendarEvents`, sends `SendBookingUpdated`, audits `booking.updated`.
- `CalendarService.UpdateEvent` — Google PATCH (`updateGoogleEvent`, preserves attendee RSVPs); CalDAV does delete+create. Falls back to `CreateEventForHost` when the event ID is missing — that is the #38d "rebuild after reconnect" path.
- `EmailService.SendBookingUpdated` — invitee + additional guests get a fresh ICS with a changed-fields summary.
- `BookingRepository.Update` extended to persist `additional_guests` and `answers` (long-standing gap that PR2's `_conference_error` and PR3 both depend on).
- New `BookingCalendarEventRepository.Update` for the CalDAV id-swap path.
- Routes `GET/POST /dashboard/bookings/{id}/edit`.
- New `templates/partials/booking_edit_partial.html`; "Edit" button on `booking_details_partial.html` (HTMX modal swap).
- `ErrConferencingReauthRequired` from regenerate is surfaced as `?error=reauth_required` linking to `/dashboard/calendars`.

## Test plan

- [x] `go test ./...` — all green.
- [x] Unit tests added: `isPermanentTokenError` classification, `normalizeGuestList`, `sameStringSlice`.
- [ ] Manual UI walk-through (not yet done — flagging because per project conventions UI changes should be browser-tested):
  - [ ] Connect Zoom → click Disconnect on dashboard → row flips to "Not Connected" + `conferencing_connections` row gone.
  - [ ] Mangle a refresh token → create a Zoom-typed booking → verify booking confirms with no link, host email arrives, `_conference_error` set, dashboard shows "Reconnect required".
  - [ ] Click Reconnect → re-OAuth → verify badge flips back to "Connected".
  - [ ] Open the booking → Edit → tick "Regenerate Zoom link" → save → verify Google Calendar event was PATCHed (attendee RSVPs preserved) and invitee got "Updated" email with new link.
  - [ ] Edit booking → add a host note + an additional guest → save → verify calendar invite has both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)