### PR TITLE
fix: open booking edit modal via fetch (HTMX wasn't bound)

### DIFF
--- a/templates/pages/dashboard_bookings.html
+++ b/templates/pages/dashboard_bookings.html
@@ -241,6 +241,18 @@ function openBookingModal(bookingId) {
         });
 }
 
+function openBookingEditModal(bookingId) {
+    fetch('/dashboard/bookings/' + bookingId + '/edit')
+        .then(response => response.text())
+        .then(html => {
+            document.getElementById('booking-modal').innerHTML = html;
+            document.body.classList.add('modal-open');
+        })
+        .catch(error => {
+            console.error('Error loading booking edit form:', error);
+        });
+}
+
 function closeBookingModal(event) {
     if (event && event.target !== event.currentTarget) return;
     document.getElementById('booking-modal').innerHTML = '';

--- a/templates/partials/booking_details_partial.html
+++ b/templates/partials/booking_details_partial.html
@@ -206,10 +206,7 @@
         </div>
         <div class="modal-footer">
             {{if and .Booking (eq .Booking.Status "confirmed")}}
-            <button type="button" class="btn btn-primary"
-                    hx-get="/dashboard/bookings/{{.Booking.ID}}/edit"
-                    hx-target=".modal-overlay"
-                    hx-swap="outerHTML">Edit</button>
+            <button type="button" class="btn btn-primary" onclick="openBookingEditModal('{{.Booking.ID}}')">Edit</button>
             {{end}}
             <button type="button" class="btn btn-outline" onclick="closeBookingModal()">Close</button>
         </div>


### PR DESCRIPTION
## Summary

The Edit button on the booking details modal did nothing when clicked.

The modal is loaded by \`openBookingModal\` in \`dashboard_bookings.html\` via vanilla \`fetch\` + \`innerHTML\` — HTMX is not invoked, so the \`hx-get\` attribute I added to the Edit button was never processed and the click was a no-op.

Switched the Edit button to a plain \`onclick\` calling a new \`openBookingEditModal\` helper that mirrors the existing \`openBookingModal\` exactly. Keeps both modal transitions on the same code path.

## Test plan

- [ ] Open a confirmed booking → click Edit → edit form replaces the details modal.
- [ ] Cancel button on the edit form closes the modal.
- [ ] Save → redirect to bookings list with success flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)