### PR TITLE
Refactor calendar event sync to support multi-host pooling

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -376,6 +376,60 @@ type BookingCalendarEvent struct {
 	CreatedAt  SQLiteTime `json:"created_at" db:"created_at"`
 }
 
+// HostedEventStatus represents the status of a hosted event
+type HostedEventStatus string
+
+const (
+	HostedEventStatusScheduled HostedEventStatus = "scheduled"
+	HostedEventStatusCancelled HostedEventStatus = "cancelled"
+)
+
+// HostedEvent represents a host-driven scheduled meeting (the inverse of an
+// invitee-driven Booking). Hosts pick the time and attendees directly.
+type HostedEvent struct {
+	ID             string               `json:"id" db:"id"`
+	TenantID       string               `json:"tenant_id" db:"tenant_id"`
+	HostID         string               `json:"host_id" db:"host_id"`
+	TemplateID     *string              `json:"template_id" db:"template_id"`
+	Title          string               `json:"title" db:"title"`
+	Description    string               `json:"description" db:"description"`
+	StartTime      SQLiteTime           `json:"start_time" db:"start_time"`
+	EndTime        SQLiteTime           `json:"end_time" db:"end_time"`
+	Duration       int                  `json:"duration" db:"duration"`
+	Timezone       string               `json:"timezone" db:"timezone"`
+	LocationType   ConferencingProvider `json:"location_type" db:"location_type"`
+	CustomLocation string               `json:"custom_location" db:"custom_location"`
+	CalendarID     string               `json:"calendar_id" db:"calendar_id"`
+	ConferenceLink string               `json:"conference_link" db:"conference_link"`
+	Status         HostedEventStatus    `json:"status" db:"status"`
+	CancelReason   string               `json:"cancel_reason" db:"cancel_reason"`
+	ReminderSent   bool                 `json:"reminder_sent" db:"reminder_sent"`
+	IsArchived     bool                 `json:"is_archived" db:"is_archived"`
+	CreatedAt      SQLiteTime           `json:"created_at" db:"created_at"`
+	UpdatedAt      SQLiteTime           `json:"updated_at" db:"updated_at"`
+}
+
+// HostedEventAttendee is one attendee on a hosted event.
+type HostedEventAttendee struct {
+	ID            string     `json:"id" db:"id"`
+	HostedEventID string     `json:"hosted_event_id" db:"hosted_event_id"`
+	Email         string     `json:"email" db:"email"`
+	Name          string     `json:"name" db:"name"`
+	ContactID     *string    `json:"contact_id" db:"contact_id"`
+	CreatedAt     SQLiteTime `json:"created_at" db:"created_at"`
+}
+
+// HostedEventCalendarEvent tracks the per-host calendar events created for a
+// hosted event (parallel to BookingCalendarEvent for bookings).
+type HostedEventCalendarEvent struct {
+	ID            string     `json:"id" db:"id"`
+	HostedEventID string     `json:"hosted_event_id" db:"hosted_event_id"`
+	HostID        string     `json:"host_id" db:"host_id"`
+	CalendarID    string     `json:"calendar_id" db:"calendar_id"`
+	EventID       string     `json:"event_id" db:"event_id"`
+	CreatedAt     SQLiteTime `json:"created_at" db:"created_at"`
+}
+
 // Custom JSON types for PostgreSQL arrays and JSONB
 
 // IntSlice is a slice of integers that can be stored as JSONB

--- a/internal/repository/hosted_event.go
+++ b/internal/repository/hosted_event.go
@@ -1,0 +1,203 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+// HostedEventRepository handles hosted_events database operations.
+type HostedEventRepository struct {
+	db     *sql.DB
+	driver string
+}
+
+func (r *HostedEventRepository) Create(ctx context.Context, e *models.HostedEvent) error {
+	query := q(r.driver, `
+		INSERT INTO hosted_events (
+			id, tenant_id, host_id, template_id, title, description,
+			start_time, end_time, duration, timezone, location_type, custom_location,
+			calendar_id, conference_link, status, cancel_reason, reminder_sent, is_archived,
+			created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+	`)
+	_, err := r.db.ExecContext(ctx, query,
+		e.ID, e.TenantID, e.HostID, e.TemplateID, e.Title, e.Description,
+		e.StartTime, e.EndTime, e.Duration, e.Timezone, e.LocationType, e.CustomLocation,
+		e.CalendarID, e.ConferenceLink, e.Status, e.CancelReason, e.ReminderSent, e.IsArchived,
+		e.CreatedAt, e.UpdatedAt)
+	return err
+}
+
+const hostedEventSelect = `
+	SELECT id, tenant_id, host_id, template_id, title, description,
+	       start_time, end_time, duration, timezone, location_type, custom_location,
+	       calendar_id, conference_link, status, cancel_reason,
+	       COALESCE(reminder_sent, false), COALESCE(is_archived, false),
+	       created_at, updated_at
+	FROM hosted_events
+`
+
+func scanHostedEvent(row interface {
+	Scan(...interface{}) error
+}) (*models.HostedEvent, error) {
+	e := &models.HostedEvent{}
+	err := row.Scan(
+		&e.ID, &e.TenantID, &e.HostID, &e.TemplateID, &e.Title, &e.Description,
+		&e.StartTime, &e.EndTime, &e.Duration, &e.Timezone, &e.LocationType, &e.CustomLocation,
+		&e.CalendarID, &e.ConferenceLink, &e.Status, &e.CancelReason,
+		&e.ReminderSent, &e.IsArchived,
+		&e.CreatedAt, &e.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+func (r *HostedEventRepository) GetByID(ctx context.Context, id string) (*models.HostedEvent, error) {
+	query := q(r.driver, hostedEventSelect+` WHERE id = $1`)
+	e, err := scanHostedEvent(r.db.QueryRowContext(ctx, query, id))
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return e, err
+}
+
+func (r *HostedEventRepository) Update(ctx context.Context, e *models.HostedEvent) error {
+	query := q(r.driver, `
+		UPDATE hosted_events SET
+			title = $1, description = $2,
+			start_time = $3, end_time = $4, duration = $5, timezone = $6,
+			location_type = $7, custom_location = $8,
+			calendar_id = $9, conference_link = $10,
+			status = $11, cancel_reason = $12,
+			reminder_sent = $13, is_archived = $14,
+			updated_at = $15
+		WHERE id = $16
+	`)
+	_, err := r.db.ExecContext(ctx, query,
+		e.Title, e.Description,
+		e.StartTime, e.EndTime, e.Duration, e.Timezone,
+		e.LocationType, e.CustomLocation,
+		e.CalendarID, e.ConferenceLink,
+		e.Status, e.CancelReason,
+		e.ReminderSent, e.IsArchived,
+		e.UpdatedAt, e.ID)
+	return err
+}
+
+func (r *HostedEventRepository) ListByHost(ctx context.Context, hostID string, includeArchived bool) ([]*models.HostedEvent, error) {
+	query := hostedEventSelect + ` WHERE host_id = $1`
+	if !includeArchived {
+		query += ` AND (is_archived = false OR is_archived IS NULL)`
+	}
+	query += ` ORDER BY start_time DESC`
+	rows, err := r.db.QueryContext(ctx, q(r.driver, query), hostID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("Error closing rows: %v", err)
+		}
+	}()
+
+	var out []*models.HostedEvent
+	for rows.Next() {
+		e, err := scanHostedEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// GetByHostIDAndTimeRange returns non-cancelled hosted events for a host that
+// overlap the given window. excludeEventID, when non-nil, skips that event —
+// used by the conflict-detection endpoint when editing an existing event so
+// it doesn't report itself as a conflict.
+func (r *HostedEventRepository) GetByHostIDAndTimeRange(ctx context.Context, hostID string, start, end time.Time, excludeEventID *string) ([]*models.HostedEvent, error) {
+	// Placeholders must appear in strict $1,$2,...,$N order: q(driver, ...)
+	// replaces every "$N" with "?" for sqlite via plain regex substitution
+	// (see repository.go's q()), so the positional bind order falls out of
+	// the order placeholders appear in the query — not their numeric value.
+	query := hostedEventSelect + ` WHERE host_id = $1 AND status = 'scheduled' AND end_time > $2 AND start_time < $3`
+	// Format times to match the storage layout used by SQLiteTime.Value() so
+	// the TEXT comparison under sqlite is reliable. Postgres tolerates the
+	// same RFC-3339 string against TIMESTAMP columns.
+	args := []interface{}{hostID, formatTimeArg(start), formatTimeArg(end)}
+	if excludeEventID != nil {
+		query += ` AND id <> $4`
+		args = append(args, *excludeEventID)
+	}
+	query += ` ORDER BY start_time ASC`
+	rows, err := r.db.QueryContext(ctx, q(r.driver, query), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("Error closing rows: %v", err)
+		}
+	}()
+
+	var out []*models.HostedEvent
+	for rows.Next() {
+		e, err := scanHostedEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// GetUpcomingForReminders returns scheduled hosted events with start_time in
+// [start, end] that haven't had a reminder sent yet.
+func (r *HostedEventRepository) GetUpcomingForReminders(ctx context.Context, start, end time.Time) ([]*models.HostedEvent, error) {
+	query := q(r.driver, hostedEventSelect+`
+		WHERE status = 'scheduled'
+		  AND (reminder_sent = false OR reminder_sent IS NULL)
+		  AND start_time >= $1
+		  AND start_time <= $2
+		ORDER BY start_time ASC
+	`)
+	rows, err := r.db.QueryContext(ctx, query, formatTimeArg(start), formatTimeArg(end))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("Error closing rows: %v", err)
+		}
+	}()
+
+	var out []*models.HostedEvent
+	for rows.Next() {
+		e, err := scanHostedEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func (r *HostedEventRepository) MarkReminderSent(ctx context.Context, id string) error {
+	query := q(r.driver, `UPDATE hosted_events SET reminder_sent = true, updated_at = $1 WHERE id = $2`)
+	_, err := r.db.ExecContext(ctx, query, models.Now(), id)
+	return err
+}
+
+// formatTimeArg formats a time.Time into the RFC-3339 layout that
+// SQLiteTime.Value() emits, so the same string comparison works under sqlite's
+// TEXT columns regardless of how the driver would default-format raw
+// time.Time values.
+func formatTimeArg(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}

--- a/internal/repository/hosted_event_attendee.go
+++ b/internal/repository/hosted_event_attendee.go
@@ -1,0 +1,75 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"log"
+
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+// HostedEventAttendeeRepository handles hosted_event_attendees database
+// operations.
+type HostedEventAttendeeRepository struct {
+	db     *sql.DB
+	driver string
+}
+
+// ListByEvent returns all attendees for a hosted event, ordered by created_at.
+func (r *HostedEventAttendeeRepository) ListByEvent(ctx context.Context, eventID string) ([]*models.HostedEventAttendee, error) {
+	query := q(r.driver, `
+		SELECT id, hosted_event_id, email, COALESCE(name, ''), contact_id, created_at
+		FROM hosted_event_attendees
+		WHERE hosted_event_id = $1
+		ORDER BY created_at ASC
+	`)
+	rows, err := r.db.QueryContext(ctx, query, eventID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("Error closing rows: %v", err)
+		}
+	}()
+
+	var out []*models.HostedEventAttendee
+	for rows.Next() {
+		a := &models.HostedEventAttendee{}
+		if err := rows.Scan(&a.ID, &a.HostedEventID, &a.Email, &a.Name, &a.ContactID, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+// ReplaceForEvent atomically replaces the attendee list for an event:
+// deletes existing rows and inserts the new ones in a single transaction.
+// Simpler than diffing and matches the "host re-submits the form" UX.
+func (r *HostedEventAttendeeRepository) ReplaceForEvent(ctx context.Context, eventID string, attendees []*models.HostedEventAttendee) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	if _, err := tx.ExecContext(ctx, q(r.driver, `DELETE FROM hosted_event_attendees WHERE hosted_event_id = $1`), eventID); err != nil {
+		return err
+	}
+
+	insertQuery := q(r.driver, `
+		INSERT INTO hosted_event_attendees (id, hosted_event_id, email, name, contact_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`)
+	for _, a := range attendees {
+		a.HostedEventID = eventID
+		if _, err := tx.ExecContext(ctx, insertQuery,
+			a.ID, a.HostedEventID, a.Email, a.Name, a.ContactID, a.CreatedAt); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}

--- a/internal/repository/hosted_event_calendar_event.go
+++ b/internal/repository/hosted_event_calendar_event.go
@@ -1,0 +1,62 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+// HostedEventCalendarEventRepository tracks per-host calendar events for a
+// hosted event (parallel to BookingCalendarEventRepository).
+type HostedEventCalendarEventRepository struct {
+	db     *sql.DB
+	driver string
+}
+
+func (r *HostedEventCalendarEventRepository) Create(ctx context.Context, e *models.HostedEventCalendarEvent) error {
+	query := q(r.driver, `
+		INSERT INTO hosted_event_calendar_events (id, hosted_event_id, host_id, calendar_id, event_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`)
+	_, err := r.db.ExecContext(ctx, query,
+		e.ID, e.HostedEventID, e.HostID, e.CalendarID, e.EventID, e.CreatedAt)
+	return err
+}
+
+func (r *HostedEventCalendarEventRepository) GetByHostedEventID(ctx context.Context, eventID string) ([]*models.HostedEventCalendarEvent, error) {
+	query := q(r.driver, `
+		SELECT id, hosted_event_id, host_id, calendar_id, event_id, created_at
+		FROM hosted_event_calendar_events
+		WHERE hosted_event_id = $1
+	`)
+	rows, err := r.db.QueryContext(ctx, query, eventID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []*models.HostedEventCalendarEvent
+	for rows.Next() {
+		e := &models.HostedEventCalendarEvent{}
+		if err := rows.Scan(&e.ID, &e.HostedEventID, &e.HostID, &e.CalendarID, &e.EventID, &e.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func (r *HostedEventCalendarEventRepository) DeleteByHostedEventID(ctx context.Context, eventID string) error {
+	query := q(r.driver, `DELETE FROM hosted_event_calendar_events WHERE hosted_event_id = $1`)
+	_, err := r.db.ExecContext(ctx, query, eventID)
+	return err
+}
+
+// Update changes the event_id (and optionally calendar_id) of a tracking row.
+// Used after a CalDAV-style replace or a fall-back create on update.
+func (r *HostedEventCalendarEventRepository) Update(ctx context.Context, e *models.HostedEventCalendarEvent) error {
+	query := q(r.driver, `UPDATE hosted_event_calendar_events SET event_id = $1, calendar_id = $2 WHERE id = $3`)
+	_, err := r.db.ExecContext(ctx, query, e.EventID, e.CalendarID, e.ID)
+	return err
+}

--- a/internal/repository/hosted_event_test.go
+++ b/internal/repository/hosted_event_test.go
@@ -1,0 +1,198 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+func TestHostedEventRepository_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+	}{
+		{"PostgreSQL", "postgres"},
+		{"SQLite", "sqlite"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.driver == "postgres" && !isPostgresAvailable() {
+				t.Skip("PostgreSQL not available")
+			}
+
+			db, cleanup := setupTestDB(t, tt.driver)
+			defer cleanup()
+			repos := NewRepositories(db, tt.driver)
+			ctx := context.Background()
+
+			tenantID, hostID := seedHostedEventParents(t, repos)
+
+			start := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+			end := start.Add(30 * time.Minute)
+			templateID := "" // nullable; pass nil
+			event := &models.HostedEvent{
+				ID:           uuid.New().String(),
+				TenantID:     tenantID,
+				HostID:       hostID,
+				TemplateID:   nullableID(templateID),
+				Title:        "Coffee chat",
+				Description:  "intro",
+				StartTime:    models.NewSQLiteTime(start),
+				EndTime:      models.NewSQLiteTime(end),
+				Duration:     30,
+				Timezone:     "UTC",
+				LocationType: models.ConferencingProviderGoogleMeet,
+				Status:       models.HostedEventStatusScheduled,
+				CreatedAt:    models.Now(),
+				UpdatedAt:    models.Now(),
+			}
+			if err := repos.HostedEvent.Create(ctx, event); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			got, err := repos.HostedEvent.GetByID(ctx, event.ID)
+			if err != nil {
+				t.Fatalf("GetByID: %v", err)
+			}
+			if got == nil || got.Title != "Coffee chat" {
+				t.Fatalf("unexpected event: %+v", got)
+			}
+
+			// ListByHost should return it.
+			list, err := repos.HostedEvent.ListByHost(ctx, hostID, false)
+			if err != nil {
+				t.Fatalf("ListByHost: %v", err)
+			}
+			if len(list) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(list))
+			}
+
+			// GetByHostIDAndTimeRange should overlap.
+			overlapping, err := repos.HostedEvent.GetByHostIDAndTimeRange(ctx, hostID, start.Add(-time.Hour), end.Add(time.Hour), nil)
+			if err != nil {
+				t.Fatalf("GetByHostIDAndTimeRange: %v", err)
+			}
+			if len(overlapping) != 1 {
+				t.Fatalf("expected 1 overlapping, got %d", len(overlapping))
+			}
+
+			// excludeEventID filter.
+			selfExcluded, err := repos.HostedEvent.GetByHostIDAndTimeRange(ctx, hostID, start.Add(-time.Hour), end.Add(time.Hour), &event.ID)
+			if err != nil {
+				t.Fatalf("GetByHostIDAndTimeRange (exclude): %v", err)
+			}
+			if len(selfExcluded) != 0 {
+				t.Fatalf("expected 0 when excluding self, got %d", len(selfExcluded))
+			}
+
+			// MarkReminderSent.
+			if err := repos.HostedEvent.MarkReminderSent(ctx, event.ID); err != nil {
+				t.Fatalf("MarkReminderSent: %v", err)
+			}
+			fresh, _ := repos.HostedEvent.GetByID(ctx, event.ID)
+			if !fresh.ReminderSent {
+				t.Fatal("ReminderSent not persisted")
+			}
+		})
+	}
+}
+
+func TestHostedEventAttendeeRepository_ReplaceForEvent(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+	}{
+		{"PostgreSQL", "postgres"},
+		{"SQLite", "sqlite"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.driver == "postgres" && !isPostgresAvailable() {
+				t.Skip("PostgreSQL not available")
+			}
+			db, cleanup := setupTestDB(t, tt.driver)
+			defer cleanup()
+			repos := NewRepositories(db, tt.driver)
+			ctx := context.Background()
+
+			tenantID, hostID := seedHostedEventParents(t, repos)
+			event := &models.HostedEvent{
+				ID: uuid.New().String(), TenantID: tenantID, HostID: hostID,
+				Title: "x", Duration: 30, Timezone: "UTC",
+				StartTime: models.Now(), EndTime: models.Now(),
+				LocationType: models.ConferencingProviderGoogleMeet,
+				Status:       models.HostedEventStatusScheduled,
+				CreatedAt:    models.Now(), UpdatedAt: models.Now(),
+			}
+			if err := repos.HostedEvent.Create(ctx, event); err != nil {
+				t.Fatalf("event create: %v", err)
+			}
+
+			first := []*models.HostedEventAttendee{
+				{ID: uuid.New().String(), Email: "a@example.com", Name: "A", CreatedAt: models.Now()},
+				{ID: uuid.New().String(), Email: "b@example.com", Name: "B", CreatedAt: models.Now()},
+			}
+			if err := repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, first); err != nil {
+				t.Fatalf("Replace 1: %v", err)
+			}
+
+			got, err := repos.HostedEventAttendee.ListByEvent(ctx, event.ID)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if len(got) != 2 {
+				t.Fatalf("expected 2 attendees, got %d", len(got))
+			}
+
+			// Replace with a different set; previous rows must be gone.
+			second := []*models.HostedEventAttendee{
+				{ID: uuid.New().String(), Email: "c@example.com", Name: "C", CreatedAt: models.Now()},
+			}
+			if err := repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, second); err != nil {
+				t.Fatalf("Replace 2: %v", err)
+			}
+			got2, _ := repos.HostedEventAttendee.ListByEvent(ctx, event.ID)
+			if len(got2) != 1 || got2[0].Email != "c@example.com" {
+				t.Fatalf("unexpected after replace 2: %+v", got2)
+			}
+		})
+	}
+}
+
+func nullableID(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// seedHostedEventParents inserts the minimum tenant + host needed to satisfy
+// hosted_events foreign keys. Returns the IDs.
+func seedHostedEventParents(t *testing.T, repos *Repositories) (tenantID, hostID string) {
+	t.Helper()
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+
+	tenant := &models.Tenant{
+		ID: uuid.New().String(), Slug: "t-" + suffix, Name: "Tenant",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Tenant.Create(ctx, tenant); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	host := &models.Host{
+		ID: uuid.New().String(), TenantID: tenant.ID,
+		Email: "h-" + suffix + "@example.com", PasswordHash: "x",
+		Name: "Host", Slug: "host-" + suffix, Timezone: "UTC",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Host.Create(ctx, host); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+	return tenant.ID, host.ID
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -13,39 +13,45 @@ import (
 
 // Repositories holds all repository instances
 type Repositories struct {
-	Tenant               *TenantRepository
-	Host                 *HostRepository
-	Calendar             *CalendarRepository
-	ProviderCalendar     *ProviderCalendarRepository
-	Conferencing         *ConferencingRepository
-	Template             *TemplateRepository
-	Booking              *BookingRepository
-	Session              *SessionRepository
-	WorkingHours         *WorkingHoursRepository
-	AuditLog             *AuditLogRepository
-	SignupConversion     *SignupConversionRepository
-	TemplateHost         *TemplateHostRepository
-	BookingCalendarEvent *BookingCalendarEventRepository
-	Contact              *ContactRepository
+	Tenant                   *TenantRepository
+	Host                     *HostRepository
+	Calendar                 *CalendarRepository
+	ProviderCalendar         *ProviderCalendarRepository
+	Conferencing             *ConferencingRepository
+	Template                 *TemplateRepository
+	Booking                  *BookingRepository
+	Session                  *SessionRepository
+	WorkingHours             *WorkingHoursRepository
+	AuditLog                 *AuditLogRepository
+	SignupConversion         *SignupConversionRepository
+	TemplateHost             *TemplateHostRepository
+	BookingCalendarEvent     *BookingCalendarEventRepository
+	Contact                  *ContactRepository
+	HostedEvent              *HostedEventRepository
+	HostedEventAttendee      *HostedEventAttendeeRepository
+	HostedEventCalendarEvent *HostedEventCalendarEventRepository
 }
 
 // NewRepositories creates all repositories
 func NewRepositories(db *sql.DB, driver string) *Repositories {
 	return &Repositories{
-		Tenant:               &TenantRepository{db: db, driver: driver},
-		Host:                 &HostRepository{db: db, driver: driver},
-		Calendar:             &CalendarRepository{db: db, driver: driver},
-		ProviderCalendar:     &ProviderCalendarRepository{db: db, driver: driver},
-		Conferencing:         &ConferencingRepository{db: db, driver: driver},
-		Template:             &TemplateRepository{db: db, driver: driver},
-		Booking:              &BookingRepository{db: db, driver: driver},
-		Session:              &SessionRepository{db: db, driver: driver},
-		WorkingHours:         &WorkingHoursRepository{db: db, driver: driver},
-		AuditLog:             &AuditLogRepository{db: db, driver: driver},
-		SignupConversion:     &SignupConversionRepository{db: db, driver: driver},
-		TemplateHost:         &TemplateHostRepository{db: db, driver: driver},
-		BookingCalendarEvent: &BookingCalendarEventRepository{db: db, driver: driver},
-		Contact:              &ContactRepository{db: db, driver: driver},
+		Tenant:                   &TenantRepository{db: db, driver: driver},
+		Host:                     &HostRepository{db: db, driver: driver},
+		Calendar:                 &CalendarRepository{db: db, driver: driver},
+		ProviderCalendar:         &ProviderCalendarRepository{db: db, driver: driver},
+		Conferencing:             &ConferencingRepository{db: db, driver: driver},
+		Template:                 &TemplateRepository{db: db, driver: driver},
+		Booking:                  &BookingRepository{db: db, driver: driver},
+		Session:                  &SessionRepository{db: db, driver: driver},
+		WorkingHours:             &WorkingHoursRepository{db: db, driver: driver},
+		AuditLog:                 &AuditLogRepository{db: db, driver: driver},
+		SignupConversion:         &SignupConversionRepository{db: db, driver: driver},
+		TemplateHost:             &TemplateHostRepository{db: db, driver: driver},
+		BookingCalendarEvent:     &BookingCalendarEventRepository{db: db, driver: driver},
+		Contact:                  &ContactRepository{db: db, driver: driver},
+		HostedEvent:              &HostedEventRepository{db: db, driver: driver},
+		HostedEventAttendee:      &HostedEventAttendeeRepository{db: db, driver: driver},
+		HostedEventCalendarEvent: &HostedEventCalendarEventRepository{db: db, driver: driver},
 	}
 }
 

--- a/internal/services/booking.go
+++ b/internal/services/booking.go
@@ -41,6 +41,7 @@ type BookingService struct {
 	cfg          *config.Config
 	repos        *repository.Repositories
 	calendar     *CalendarService
+	syncer       *CalendarEventSyncer
 	conferencing *ConferencingService
 	email        *EmailService
 	auditLog     *AuditLogService
@@ -52,6 +53,7 @@ func NewBookingService(
 	cfg *config.Config,
 	repos *repository.Repositories,
 	calendar *CalendarService,
+	syncer *CalendarEventSyncer,
 	conferencing *ConferencingService,
 	email *EmailService,
 	auditLog *AuditLogService,
@@ -61,6 +63,7 @@ func NewBookingService(
 		cfg:          cfg,
 		repos:        repos,
 		calendar:     calendar,
+		syncer:       syncer,
 		conferencing: conferencing,
 		email:        email,
 		auditLog:     auditLog,
@@ -319,35 +322,27 @@ func (s *BookingService) CancelBooking(ctx context.Context, bookingID, cancelled
 	return nil
 }
 
-// deleteAllCalendarEvents deletes calendar events for all hosts (pooled and legacy single-host)
+// deleteAllCalendarEvents deletes calendar events for all hosts. Tracked rows
+// (pooled and post-refactor single-host) flow through the syncer; pre-refactor
+// bookings that only have booking.CalendarEventID + template.CalendarID still
+// fall back to a direct DeleteEvent call.
 func (s *BookingService) deleteAllCalendarEvents(ctx context.Context, booking *models.Booking) {
-	// First, try to delete events from booking_calendar_events table (pooled hosts)
-	calEvents, err := s.repos.BookingCalendarEvent.GetByBookingID(ctx, booking.ID)
+	deleted, err := s.syncer.Delete(ctx, ItemKindBooking, booking.ID)
 	if err != nil {
-		log.Printf("[BOOKING] Error loading calendar events for booking %s: %v", booking.ID, err)
+		log.Printf("[BOOKING] Error during syncer delete for booking %s: %v", booking.ID, err)
 	}
-
-	if len(calEvents) > 0 {
-		// Delete events for all pooled hosts
-		for _, ce := range calEvents {
-			if err := s.calendar.DeleteEvent(ctx, ce.HostID, ce.CalendarID, ce.EventID); err != nil {
-				log.Printf("[BOOKING] Error deleting calendar event %s for host %s: %v", ce.EventID, ce.HostID, err)
-			} else {
-				log.Printf("[BOOKING] Deleted calendar event %s for host %s", ce.EventID, ce.HostID)
-			}
-		}
-		// Clean up the booking_calendar_events records
-		if err := s.repos.BookingCalendarEvent.DeleteByBookingID(ctx, booking.ID); err != nil {
-			log.Printf("[BOOKING] Error deleting booking_calendar_events records: %v", err)
-		}
-	} else if booking.CalendarEventID != "" {
-		// Fall back to legacy single-host event deletion
-		template, _ := s.repos.Template.GetByID(ctx, booking.TemplateID)
-		if template != nil {
-			if err := s.calendar.DeleteEvent(ctx, booking.HostID, template.CalendarID, booking.CalendarEventID); err != nil {
-				log.Printf("[BOOKING] Error deleting legacy calendar event: %v", err)
-			}
-		}
+	if deleted > 0 {
+		return
+	}
+	if booking.CalendarEventID == "" {
+		return
+	}
+	template, _ := s.repos.Template.GetByID(ctx, booking.TemplateID)
+	if template == nil {
+		return
+	}
+	if err := s.calendar.DeleteEvent(ctx, booking.HostID, template.CalendarID, booking.CalendarEventID); err != nil {
+		log.Printf("[BOOKING] Error deleting legacy calendar event: %v", err)
 	}
 }
 
@@ -476,53 +471,38 @@ func (s *BookingService) UpdateBooking(ctx context.Context, input UpdateBookingI
 }
 
 // updateAllCalendarEvents patches the calendar event(s) for a booking after a
-// host edit. Mirrors deleteAllCalendarEvents: pooled-host events live in
-// booking_calendar_events; legacy single-host bookings have only
-// booking.CalendarEventID with template.CalendarID as the calendar.
+// host edit. Tracked rows flow through the syncer (which preserves the
+// per-host ID and writes back any replacement ID returned by the provider).
+// For pre-refactor bookings that only have booking.CalendarEventID +
+// template.CalendarID, falls back to a direct UpdateEvent call.
 func (s *BookingService) updateAllCalendarEvents(ctx context.Context, details *BookingWithDetails, template *models.MeetingTemplate) {
-	calEvents, err := s.repos.BookingCalendarEvent.GetByBookingID(ctx, details.Booking.ID)
+	rows, err := s.repos.BookingCalendarEvent.GetByBookingID(ctx, details.Booking.ID)
 	if err != nil {
 		log.Printf("[BOOKING] Error loading calendar events for booking %s: %v", details.Booking.ID, err)
 	}
 
-	if len(calEvents) > 0 {
-		for _, ce := range calEvents {
-			perHost := &BookingWithDetails{
-				Booking:  details.Booking,
-				Template: template,
-				Host:     details.Host,
-				Tenant:   details.Tenant,
-			}
-			// Force the per-host event ID through CalendarEventID so the
-			// PATCH targets the correct event for this calendar.
-			savedID := perHost.Booking.CalendarEventID
-			perHost.Booking.CalendarEventID = ce.EventID
-			newID, err := s.calendar.UpdateEvent(ctx, perHost, ce.CalendarID)
-			perHost.Booking.CalendarEventID = savedID
-			if err != nil {
-				log.Printf("[BOOKING] Error updating calendar event %s for host %s: %v", ce.EventID, ce.HostID, err)
-				continue
-			}
-			if newID != "" && newID != ce.EventID {
-				// CalDAV path replaced the event; persist the new ID.
-				ce.EventID = newID
-				if err := s.repos.BookingCalendarEvent.Update(ctx, ce); err != nil {
-					log.Printf("[BOOKING] Error updating booking_calendar_events record: %v", err)
-				}
-			}
+	if len(rows) > 0 {
+		input := s.calendar.BuildCalendarEventInputForBooking(details)
+		req := CalendarSyncRequest{
+			Kind:   ItemKindBooking,
+			ItemID: details.Booking.ID,
+			Input:  *input,
+		}
+		if err := s.syncer.Update(ctx, req); err != nil {
+			log.Printf("[BOOKING] Error during syncer update for booking %s: %v", details.Booking.ID, err)
 		}
 		return
 	}
 
 	if details.Booking.CalendarEventID != "" && template.CalendarID != "" {
-		newID, err := s.calendar.UpdateEvent(ctx, details, template.CalendarID)
+		input := s.calendar.BuildCalendarEventInputForBooking(details)
+		newID, err := s.calendar.UpdateEvent(ctx, template.CalendarID, input)
 		if err != nil {
 			log.Printf("[BOOKING] Error updating legacy calendar event: %v", err)
 			return
 		}
 		if newID != "" && newID != details.Booking.CalendarEventID {
 			details.Booking.CalendarEventID = newID
-			// Persist the swapped ID so reschedule/cancel still find the event.
 			if err := s.repos.Booking.Update(ctx, details.Booking); err != nil {
 				log.Printf("[BOOKING] Error persisting new event ID: %v", err)
 			}
@@ -704,23 +684,22 @@ func (s *BookingService) RescheduleBooking(ctx context.Context, input Reschedule
 			}
 		}
 
-		// Load pooled hosts and create calendar events for all of them
-		pooledHosts, err := s.repos.TemplateHost.GetByTemplateIDWithHost(ctx, template.ID)
+		hosts := s.bookingHostTargets(ctx, details)
+		input := s.calendar.BuildCalendarEventInputForBooking(details)
+		firstID, conferenceLink, err := s.syncer.Create(ctx, CalendarSyncRequest{
+			Kind:   ItemKindBooking,
+			ItemID: details.Booking.ID,
+			Input:  *input,
+			Hosts:  hosts,
+		})
 		if err != nil {
-			log.Printf("[RESCHEDULE] Error loading pooled hosts: %v", err)
-			pooledHosts = nil
+			log.Printf("[RESCHEDULE] Error during syncer create: %v", err)
 		}
-
-		if len(pooledHosts) > 0 {
-			s.createPooledHostCalendarEvents(ctx, details, pooledHosts)
-		} else {
-			// Single-host flow (backward compatibility)
-			eventID, err := s.calendar.CreateEvent(ctx, details)
-			if err != nil {
-				log.Printf("[RESCHEDULE] Error creating calendar event: %v", err)
-			} else if eventID != "" {
-				details.Booking.CalendarEventID = eventID
-			}
+		if firstID != "" {
+			details.Booking.CalendarEventID = firstID
+		}
+		if conferenceLink != "" && details.Booking.ConferenceLink == "" {
+			details.Booking.ConferenceLink = conferenceLink
 		}
 
 		// Update booking with new conference link and event ID
@@ -871,22 +850,22 @@ func (s *BookingService) RetryCalendarEvent(ctx context.Context, hostID, tenantI
 		Tenant:   tenant,
 	}
 
-	// Load pooled hosts for this template
-	pooledHosts, err := s.repos.TemplateHost.GetByTemplateIDWithHost(ctx, template.ID)
+	hosts := s.bookingHostTargets(ctx, details)
+	input := s.calendar.BuildCalendarEventInputForBooking(details)
+	firstID, conferenceLink, err := s.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: details.Booking.ID,
+		Input:  *input,
+		Hosts:  hosts,
+	})
 	if err != nil {
-		pooledHosts = nil
+		return fmt.Errorf("failed to create calendar event: %w", err)
 	}
-
-	if len(pooledHosts) > 0 {
-		s.createPooledHostCalendarEvents(ctx, details, pooledHosts)
-	} else {
-		eventID, err := s.calendar.CreateEvent(ctx, details)
-		if err != nil {
-			return fmt.Errorf("failed to create calendar event: %w", err)
-		}
-		if eventID != "" {
-			details.Booking.CalendarEventID = eventID
-		}
+	if firstID != "" {
+		details.Booking.CalendarEventID = firstID
+	}
+	if conferenceLink != "" && details.Booking.ConferenceLink == "" {
+		details.Booking.ConferenceLink = conferenceLink
 	}
 
 	// Update booking with the new event ID
@@ -960,29 +939,22 @@ func (s *BookingService) processConfirmedBooking(ctx context.Context, details *B
 		}
 	}
 
-	// Load pooled hosts for this template
-	pooledHosts, err := s.repos.TemplateHost.GetByTemplateIDWithHost(ctx, details.Template.ID)
+	hosts := s.bookingHostTargets(ctx, details)
+	input := s.calendar.BuildCalendarEventInputForBooking(details)
+	firstID, conferenceLink, err := s.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: details.Booking.ID,
+		Input:  *input,
+		Hosts:  hosts,
+	})
 	if err != nil {
-		log.Printf("[BOOKING] Error loading pooled hosts: %v", err)
-		// Continue with single-host flow
-		pooledHosts = nil
+		log.Printf("[BOOKING] Error during syncer create for booking %s: %v", details.Booking.ID, err)
 	}
-
-	// Create calendar events for all pooled hosts (or just owner if no pooled hosts)
-	if len(pooledHosts) > 0 {
-		s.createPooledHostCalendarEvents(ctx, details, pooledHosts)
-	} else {
-		// Single-host flow (backward compatibility)
-		log.Printf("[BOOKING] Creating calendar event for single host...")
-		eventID, err := s.calendar.CreateEvent(ctx, details)
-		if err != nil {
-			log.Printf("[BOOKING] Error creating calendar event: %v", err)
-		} else if eventID != "" {
-			log.Printf("[BOOKING] Calendar event created: %s", eventID)
-			details.Booking.CalendarEventID = eventID
-		} else {
-			log.Printf("[BOOKING] No calendar event created (no calendar configured or empty response)")
-		}
+	if firstID != "" && details.Booking.CalendarEventID == "" {
+		details.Booking.CalendarEventID = firstID
+	}
+	if conferenceLink != "" && details.Booking.ConferenceLink == "" {
+		details.Booking.ConferenceLink = conferenceLink
 	}
 
 	// Update booking with conference link and event ID
@@ -1000,81 +972,35 @@ func (s *BookingService) processConfirmedBooking(ctx context.Context, details *B
 	return nil
 }
 
-// createPooledHostCalendarEvents creates calendar events for all hosts in a pooled template
-func (s *BookingService) createPooledHostCalendarEvents(ctx context.Context, details *BookingWithDetails, pooledHosts []*models.TemplateHost) {
-	for _, th := range pooledHosts {
-		// Get the host's default calendar
-		host := th.Host
-		if host == nil {
-			var err error
-			host, err = s.repos.Host.GetByID(ctx, th.HostID)
-			if err != nil || host == nil {
-				log.Printf("[BOOKING] Error loading host %s: %v", th.HostID, err)
-				continue
-			}
-		}
-
-		// Find the host's default provider calendar (writable). Falls back to
-		// any writable provider calendar if none is configured.
-		var calendarID string
-		if host.DefaultCalendarID != nil {
-			calendarID = *host.DefaultCalendarID
-		}
-		if calendarID == "" {
-			pcs, err := s.repos.ProviderCalendar.GetByHostID(ctx, th.HostID)
-			if err != nil {
-				log.Printf("[BOOKING] No calendar found for host %s, skipping event creation", th.HostID)
-				continue
-			}
-			for _, pc := range pcs {
-				if pc.IsWritable {
-					calendarID = pc.ID
-					break
-				}
-			}
-			if calendarID == "" {
-				log.Printf("[BOOKING] No writable calendar for host %s, skipping event creation", th.HostID)
-				continue
-			}
-		}
-
-		// Create a modified details with this host's info for event creation
-		hostDetails := &BookingWithDetails{
-			Booking:  details.Booking,
-			Template: details.Template,
-			Host:     host,
-			Tenant:   details.Tenant,
-		}
-
-		// Create calendar event for this host
-		eventID, err := s.calendar.CreateEventForHost(ctx, hostDetails, calendarID)
-		if err != nil {
-			log.Printf("[BOOKING] Error creating calendar event for host %s: %v", th.HostID, err)
-			continue
-		}
-
-		if eventID != "" {
-			log.Printf("[BOOKING] Calendar event created for host %s: %s", th.HostID, eventID)
-
-			// Store in booking_calendar_events table
-			calEvent := &models.BookingCalendarEvent{
-				ID:         uuid.New().String(),
-				BookingID:  details.Booking.ID,
-				HostID:     th.HostID,
-				CalendarID: calendarID,
-				EventID:    eventID,
-				CreatedAt:  models.Now(),
-			}
-			if err := s.repos.BookingCalendarEvent.Create(ctx, calEvent); err != nil {
-				log.Printf("[BOOKING] Error storing calendar event record: %v", err)
-			}
-
-			// Store first event ID in booking for backward compatibility
-			if details.Booking.CalendarEventID == "" && th.Role == models.TemplateHostRoleOwner {
-				details.Booking.CalendarEventID = eventID
-			}
-		}
+// bookingHostTargets resolves the calendar fan-out targets for a booking:
+// pooled hosts when the template has any (owner first, siblings after), or
+// just the booking host when the template is single-host. Each target's
+// CalendarID is left empty when the syncer should resolve it from the host's
+// default + first writable fallback.
+func (s *BookingService) bookingHostTargets(ctx context.Context, details *BookingWithDetails) []HostTarget {
+	pooled, err := s.repos.TemplateHost.GetByTemplateIDWithHost(ctx, details.Template.ID)
+	if err != nil {
+		log.Printf("[BOOKING] Error loading pooled hosts: %v", err)
+		pooled = nil
 	}
+	if len(pooled) == 0 {
+		// Single-host fallback: write to the template's configured calendar.
+		return []HostTarget{{
+			HostID:     details.Booking.HostID,
+			CalendarID: details.Template.CalendarID,
+			IsOwner:    true,
+		}}
+	}
+	targets := make([]HostTarget, 0, len(pooled))
+	for _, th := range pooled {
+		targets = append(targets, HostTarget{
+			HostID:  th.HostID,
+			IsOwner: th.Role == models.TemplateHostRoleOwner,
+			// CalendarID intentionally empty — syncer resolves the host's
+			// default writable calendar.
+		})
+	}
+	return targets
 }
 
 // recordConferencingFailure marks a booking with a conferencing-link failure so

--- a/internal/services/booking_calendar_sync_test.go
+++ b/internal/services/booking_calendar_sync_test.go
@@ -1,0 +1,496 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/models"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// fakeCalendarWriter records calls and returns programmed responses. Lets
+// syncer tests run without hitting the network and lets us assert exact
+// per-host fan-out behaviour.
+type fakeCalendarWriter struct {
+	createCalls []fakeCreateCall
+	updateCalls []fakeUpdateCall
+	deleteCalls []fakeDeleteCall
+
+	// nextCreate is consulted in order; missing entries default to a generated
+	// success.
+	nextCreate []fakeCreateResult
+	// nextUpdate likewise.
+	nextUpdate []fakeUpdateResult
+
+	// createErrForCalendarID: any create call whose target calendar matches
+	// returns the configured error.
+	createErrForCalendarID map[string]error
+	updateErrForCalendarID map[string]error
+}
+
+type fakeCreateCall struct {
+	CalendarID string
+	Input      CalendarEventInput
+}
+
+type fakeUpdateCall struct {
+	CalendarID string
+	Input      CalendarEventInput
+}
+
+type fakeDeleteCall struct {
+	HostID, CalendarID, EventID string
+}
+
+type fakeCreateResult struct {
+	EventID        string
+	ConferenceLink string
+	Err            error
+}
+
+type fakeUpdateResult struct {
+	EventID string
+	Err     error
+}
+
+func (f *fakeCalendarWriter) CreateEventForHost(_ context.Context, providerCalendarID string, input *CalendarEventInput) (string, string, error) {
+	f.createCalls = append(f.createCalls, fakeCreateCall{CalendarID: providerCalendarID, Input: *input})
+	if err, ok := f.createErrForCalendarID[providerCalendarID]; ok {
+		return "", "", err
+	}
+	if len(f.nextCreate) > 0 {
+		r := f.nextCreate[0]
+		f.nextCreate = f.nextCreate[1:]
+		return r.EventID, r.ConferenceLink, r.Err
+	}
+	return "evt-" + providerCalendarID + "-" + uuid.New().String()[:8], "", nil
+}
+
+func (f *fakeCalendarWriter) UpdateEvent(_ context.Context, providerCalendarID string, input *CalendarEventInput) (string, error) {
+	f.updateCalls = append(f.updateCalls, fakeUpdateCall{CalendarID: providerCalendarID, Input: *input})
+	if err, ok := f.updateErrForCalendarID[providerCalendarID]; ok {
+		return "", err
+	}
+	if len(f.nextUpdate) > 0 {
+		r := f.nextUpdate[0]
+		f.nextUpdate = f.nextUpdate[1:]
+		return r.EventID, r.Err
+	}
+	return input.EventID, nil
+}
+
+func (f *fakeCalendarWriter) DeleteEvent(_ context.Context, hostID, providerCalendarID, eventID string) error {
+	f.deleteCalls = append(f.deleteCalls, fakeDeleteCall{HostID: hostID, CalendarID: providerCalendarID, EventID: eventID})
+	return nil
+}
+
+// fixture holds the minimum row set needed to satisfy booking_calendar_events
+// foreign keys.
+type fixture struct {
+	tenantID   string
+	templateID string
+	bookingID  string
+	hostIDs    []string
+	calendars  map[string]string // hostID → provider_calendar.id
+}
+
+// syncerHarness bundles a syncer wired to real repositories with the fake
+// calendar writer and a seeded fixture.
+type syncerHarness struct {
+	syncer  *CalendarEventSyncer
+	fake    *fakeCalendarWriter
+	fixture *fixture
+	cleanup func()
+}
+
+func makeSyncerHarness(t *testing.T, hostCount int) *syncerHarness {
+	t.Helper()
+	db, repos, cleanup := setupTestRepos(t)
+	fix := seedFixture(t, db, repos, hostCount)
+	fake := &fakeCalendarWriter{}
+	s := &CalendarEventSyncer{
+		repos:    repos,
+		calendar: fake,
+		stores: map[ScheduledItemKind]trackingStore{
+			ItemKindBooking: &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+		},
+	}
+	return &syncerHarness{syncer: s, fake: fake, fixture: fix, cleanup: cleanup}
+}
+
+func seedFixture(t *testing.T, db *sql.DB, repos *repositoryWrapper, hostCount int) *fixture {
+	t.Helper()
+	ctx := context.Background()
+	short := func(s string) string { return s[:8] }
+
+	tenant := &models.Tenant{
+		ID: uuid.New().String(), Slug: "t-" + uuid.New().String()[:6], Name: "Test Tenant",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Tenant.Create(ctx, tenant); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+
+	hosts := make([]string, 0, hostCount)
+	cals := map[string]string{}
+	for i := 0; i < hostCount; i++ {
+		host := &models.Host{
+			ID:           uuid.New().String(),
+			TenantID:     tenant.ID,
+			Email:        "h" + uuid.New().String()[:4] + "@example.com",
+			PasswordHash: "x",
+			Name:         "Host",
+			Slug:         "host-" + uuid.New().String()[:6],
+			Timezone:     "UTC",
+			CreatedAt:    models.Now(),
+			UpdatedAt:    models.Now(),
+		}
+		if err := repos.Host.Create(ctx, host); err != nil {
+			t.Fatalf("create host: %v", err)
+		}
+		hosts = append(hosts, host.ID)
+
+		conn := &models.CalendarConnection{
+			ID: uuid.New().String(), HostID: host.ID,
+			Provider: models.CalendarProviderGoogle, Name: "gmail",
+			CreatedAt: models.Now(), UpdatedAt: models.Now(),
+		}
+		if err := repos.Calendar.Create(ctx, conn); err != nil {
+			t.Fatalf("create calendar conn: %v", err)
+		}
+
+		pc := &models.ProviderCalendar{
+			ID: uuid.New().String(), ConnectionID: conn.ID,
+			ProviderCalendarID: "primary", Name: "Primary", Color: "#000",
+			IsPrimary: true, IsWritable: true, PollBusy: true,
+			CreatedAt: models.Now(), UpdatedAt: models.Now(),
+		}
+		if err := repos.ProviderCalendar.Create(ctx, pc); err != nil {
+			t.Fatalf("create provider calendar: %v", err)
+		}
+		cals[host.ID] = pc.ID
+	}
+
+	owner := hosts[0]
+	tmpl := &models.MeetingTemplate{
+		ID: uuid.New().String(), HostID: owner,
+		Slug: "test-" + short(uuid.New().String()), Name: "Test Template",
+		Durations: models.IntSlice{30}, LocationType: models.ConferencingProviderGoogleMeet,
+		CalendarID: cals[owner], MaxScheduleDays: 30, IsActive: true,
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Template.Create(ctx, tmpl); err != nil {
+		t.Fatalf("create template: %v", err)
+	}
+
+	bk := &models.Booking{
+		ID: uuid.New().String(), TemplateID: tmpl.ID, HostID: owner,
+		Token: uuid.New().String(), Status: models.BookingStatusConfirmed,
+		StartTime: models.Now(), EndTime: models.Now(), Duration: 30,
+		InviteeName: "Inv", InviteeEmail: "i@example.com",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Booking.Create(ctx, bk); err != nil {
+		t.Fatalf("create booking: %v", err)
+	}
+
+	return &fixture{
+		tenantID:   tenant.ID,
+		templateID: tmpl.ID,
+		bookingID:  bk.ID,
+		hostIDs:    hosts,
+		calendars:  cals,
+	}
+}
+
+// repositoryWrapper is just an alias to keep the seed signature compact.
+type repositoryWrapper = repository.Repositories
+
+func basicInput() CalendarEventInput {
+	return CalendarEventInput{
+		Summary:     "Sync test",
+		Description: "Body",
+		Start:       time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC),
+		End:         time.Date(2026, 1, 2, 11, 0, 0, 0, time.UTC),
+		Attendees:   []string{"a@example.com"},
+		HostName:    "Host",
+		HostEmail:   "host@example.com",
+	}
+}
+
+func ownerTarget(fix *fixture) HostTarget {
+	return HostTarget{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true}
+}
+
+func TestSyncerCreate_OneHost_WritesEventAndTrackingRow(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	firstID, link, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: h.fixture.bookingID,
+		Input:  basicInput(),
+		Hosts:  []HostTarget{ownerTarget(h.fixture)},
+	})
+	if err != nil {
+		t.Fatalf("Create returned err: %v", err)
+	}
+	if firstID == "" {
+		t.Fatal("expected non-empty first event ID")
+	}
+	if link != "" {
+		t.Fatalf("expected empty conference link, got %q", link)
+	}
+	if got := len(h.fake.createCalls); got != 1 {
+		t.Fatalf("expected 1 fake create call, got %d", got)
+	}
+	rows, err := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, h.fixture.bookingID)
+	if err != nil {
+		t.Fatalf("GetByBookingID: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 tracking row, got %d", len(rows))
+	}
+	if rows[0].EventID != firstID {
+		t.Fatalf("tracking row event_id = %q, want %q", rows[0].EventID, firstID)
+	}
+}
+
+func TestSyncerCreate_PooledHosts_OneEventPerHost(t *testing.T) {
+	h := makeSyncerHarness(t, 3)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+
+	hosts := []HostTarget{
+		{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true},
+		{HostID: fix.hostIDs[1], CalendarID: fix.calendars[fix.hostIDs[1]]},
+		{HostID: fix.hostIDs[2], CalendarID: fix.calendars[fix.hostIDs[2]]},
+	}
+	firstID, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: fix.bookingID,
+		Input:  basicInput(),
+		Hosts:  hosts,
+	})
+	if err != nil {
+		t.Fatalf("Create returned err: %v", err)
+	}
+	if got := len(h.fake.createCalls); got != 3 {
+		t.Fatalf("expected 3 fake create calls, got %d", got)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 tracking rows, got %d", len(rows))
+	}
+	var ownerRow *models.BookingCalendarEvent
+	for _, r := range rows {
+		if r.HostID == fix.hostIDs[0] {
+			ownerRow = r
+			break
+		}
+	}
+	if ownerRow == nil {
+		t.Fatal("owner tracking row missing")
+	}
+	if firstID != ownerRow.EventID {
+		t.Fatalf("first event ID %q does not match owner tracking row %q", firstID, ownerRow.EventID)
+	}
+}
+
+func TestSyncerCreate_PerHostFailureContinues(t *testing.T) {
+	h := makeSyncerHarness(t, 3)
+	defer h.cleanup()
+	fix := h.fixture
+	failedCal := fix.calendars[fix.hostIDs[1]]
+	h.fake.createErrForCalendarID = map[string]error{failedCal: errors.New("boom")}
+
+	ctx := context.Background()
+	hosts := []HostTarget{
+		{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true},
+		{HostID: fix.hostIDs[1], CalendarID: fix.calendars[fix.hostIDs[1]]},
+		{HostID: fix.hostIDs[2], CalendarID: fix.calendars[fix.hostIDs[2]]},
+	}
+	if _, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: fix.bookingID,
+		Input:  basicInput(),
+		Hosts:  hosts,
+	}); err != nil {
+		t.Fatalf("Create returned err: %v", err)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 tracking rows (failed host skipped), got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.HostID == fix.hostIDs[1] {
+			t.Fatal("failed host should not have a tracking row")
+		}
+	}
+}
+
+func TestSyncerCreate_GoogleMeet_ReturnsConferenceLink(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	h.fake.nextCreate = []fakeCreateResult{
+		{EventID: "g-evt-1", ConferenceLink: "https://meet.google.com/xyz-abc-def"},
+	}
+
+	_, link, err := h.syncer.Create(context.Background(), CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: h.fixture.bookingID,
+		Input:  basicInput(),
+		Hosts:  []HostTarget{ownerTarget(h.fixture)},
+	})
+	if err != nil {
+		t.Fatalf("Create err: %v", err)
+	}
+	if link != "https://meet.google.com/xyz-abc-def" {
+		t.Fatalf("unexpected conference link: %q", link)
+	}
+}
+
+func TestSyncerUpdate_PatchesAllTrackedEvents(t *testing.T) {
+	h := makeSyncerHarness(t, 2)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+
+	hosts := []HostTarget{
+		{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true},
+		{HostID: fix.hostIDs[1], CalendarID: fix.calendars[fix.hostIDs[1]]},
+	}
+	if _, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(), Hosts: hosts,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.fake.updateCalls = nil
+
+	if err := h.syncer.Update(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(),
+	}); err != nil {
+		t.Fatalf("Update err: %v", err)
+	}
+	if got := len(h.fake.updateCalls); got != 2 {
+		t.Fatalf("expected 2 update calls, got %d", got)
+	}
+}
+
+// Replacement event_id from CalDAV-style delete+create path is persisted
+// back to the tracking row.
+func TestSyncerUpdate_CalDAVNewEventID_PersistsToTrackingRow(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+
+	if _, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(),
+		Hosts: []HostTarget{ownerTarget(fix)},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.fake.nextUpdate = []fakeUpdateResult{{EventID: "fresh-id-from-caldav"}}
+
+	if err := h.syncer.Update(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(),
+	}); err != nil {
+		t.Fatalf("Update err: %v", err)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 tracking row, got %d", len(rows))
+	}
+	if rows[0].EventID != "fresh-id-from-caldav" {
+		t.Fatalf("tracking row was not updated to the replacement ID; got %q", rows[0].EventID)
+	}
+}
+
+// When the prior event_id is empty (an earlier create failed and the row was
+// seeded with EventID=""), a subsequent Update must persist whatever new ID
+// the calendar writer returns.
+func TestSyncerUpdate_PriorIDEmpty_PersistsCreatedID(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+	owner := fix.hostIDs[0]
+
+	// Seed a tracking row with EventID="".
+	if err := h.syncer.repos.BookingCalendarEvent.Create(ctx, &models.BookingCalendarEvent{
+		ID:         uuid.New().String(),
+		BookingID:  fix.bookingID,
+		HostID:     owner,
+		CalendarID: fix.calendars[owner],
+		EventID:    "",
+		CreatedAt:  models.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	h.fake.nextUpdate = []fakeUpdateResult{{EventID: "first-create-id"}}
+
+	if err := h.syncer.Update(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(),
+	}); err != nil {
+		t.Fatalf("Update err: %v", err)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 tracking row, got %d", len(rows))
+	}
+	if rows[0].EventID != "first-create-id" {
+		t.Fatalf("tracking row event_id = %q, want first-create-id", rows[0].EventID)
+	}
+}
+
+func TestSyncerDelete_RemovesAllTrackedRows(t *testing.T) {
+	h := makeSyncerHarness(t, 2)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+
+	hosts := []HostTarget{
+		{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true},
+		{HostID: fix.hostIDs[1], CalendarID: fix.calendars[fix.hostIDs[1]]},
+	}
+	if _, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(), Hosts: hosts,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.fake.deleteCalls = nil
+
+	count, err := h.syncer.Delete(ctx, ItemKindBooking, fix.bookingID)
+	if err != nil {
+		t.Fatalf("Delete err: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected count=2, got %d", count)
+	}
+	if got := len(h.fake.deleteCalls); got != 2 {
+		t.Fatalf("expected 2 delete calls, got %d", got)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 0 {
+		t.Fatalf("expected 0 tracking rows after delete, got %d", len(rows))
+	}
+}
+
+func TestSyncerDelete_NoTrackedRows_ReturnsZero(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	count, err := h.syncer.Delete(context.Background(), ItemKindBooking, "no-such-booking")
+	if err != nil {
+		t.Fatalf("Delete err: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected count=0, got %d", count)
+	}
+}

--- a/internal/services/calendar.go
+++ b/internal/services/calendar.go
@@ -566,61 +566,160 @@ func (s *CalendarService) getGoogleBusyTimesMulti(ctx context.Context, conn *mod
 	return out, nil
 }
 
-// CreateEvent creates a calendar event in the template's configured calendar.
-// details.Template.CalendarID is interpreted as a provider_calendars.id.
+// CalendarEventInput is the provider-agnostic shape of a calendar event the
+// caller wants written. Booking and hosted-event flows both build one of these
+// and hand it to CreateEventForHost / UpdateEvent.
+//
+// Description must be already-composed by the caller — providers render it
+// verbatim. The booking-side adapter (BuildCalendarEventInputForBooking)
+// composes the agenda and reschedule-link suffixes that booking flows need;
+// the hosted-event flow does not.
+type CalendarEventInput struct {
+	Summary            string
+	Description        string
+	Start              time.Time
+	End                time.Time
+	LocationType       models.ConferencingProvider
+	CustomLocation     string
+	ConferenceLink     string
+	Attendees          []string
+	HostName           string
+	HostEmail          string
+	EventID            string // empty for create; set for update
+	MeetIdempotencyKey string // requestId for Google Meet conferenceData.createRequest
+}
+
+// calendarEventWriter is the narrow contract that CalendarEventSyncer depends
+// on. *CalendarService satisfies it; tests inject a fake.
+type calendarEventWriter interface {
+	CreateEventForHost(ctx context.Context, providerCalendarID string, input *CalendarEventInput) (eventID, conferenceLink string, err error)
+	UpdateEvent(ctx context.Context, providerCalendarID string, input *CalendarEventInput) (eventID string, err error)
+	DeleteEvent(ctx context.Context, hostID, providerCalendarID, eventID string) error
+}
+
+// BuildCalendarEventInputForBooking composes a CalendarEventInput from a
+// BookingWithDetails. Description includes the template description, any
+// invitee-supplied agenda, host notes (when surfacing on update), and the
+// reschedule link — i.e. what the previous booking-coupled providers used to
+// build inline.
+func (s *CalendarService) BuildCalendarEventInputForBooking(details *BookingWithDetails) *CalendarEventInput {
+	attendees := make([]string, 0, 1+len(details.Booking.AdditionalGuests))
+	if details.Booking.InviteeEmail != "" {
+		attendees = append(attendees, details.Booking.InviteeEmail)
+	}
+	for _, guest := range details.Booking.AdditionalGuests {
+		if isValidEmail(guest) {
+			attendees = append(attendees, guest)
+		}
+	}
+
+	description := details.Template.Description
+	if details.Booking.Answers != nil {
+		if agenda, ok := details.Booking.Answers["agenda"].(string); ok && agenda != "" {
+			if description != "" {
+				description += "\n\n"
+			}
+			description += "Agenda:\n" + agenda
+		}
+		if notes, ok := details.Booking.Answers["host_notes"].(string); ok && notes != "" {
+			if description != "" {
+				description += "\n\n"
+			}
+			description += "Notes from host:\n" + notes
+		}
+	}
+	rescheduleURL := fmt.Sprintf("%s/m/%s/%s/%s/reschedule/%s",
+		s.cfg.Server.BaseURL, details.Tenant.Slug, details.Host.Slug, details.Template.Slug, details.Booking.ID)
+	if description != "" {
+		description += "\n\n"
+	}
+	description += "Reschedule this meeting:\n" + rescheduleURL
+
+	return &CalendarEventInput{
+		Summary:            details.Template.Name + " with " + details.Booking.InviteeName,
+		Description:        description,
+		Start:              details.Booking.StartTime.Time,
+		End:                details.Booking.EndTime.Time,
+		LocationType:       details.Template.LocationType,
+		CustomLocation:     details.Template.CustomLocation,
+		ConferenceLink:     details.Booking.ConferenceLink,
+		Attendees:          attendees,
+		HostName:           details.Host.Name,
+		HostEmail:          details.Host.Email,
+		EventID:            details.Booking.CalendarEventID,
+		MeetIdempotencyKey: details.Booking.ID,
+	}
+}
+
+// CreateEvent is the booking-side adapter for legacy single-host call sites
+// that still hand over a *BookingWithDetails. Builds an input and delegates.
+// The returned conferenceLink is also written onto details.Booking.ConferenceLink
+// when Google Meet creation surfaces one.
 func (s *CalendarService) CreateEvent(ctx context.Context, details *BookingWithDetails) (string, error) {
-	return s.CreateEventForHost(ctx, details, details.Template.CalendarID)
+	input := s.BuildCalendarEventInputForBooking(details)
+	eventID, conferenceLink, err := s.CreateEventForHost(ctx, details.Template.CalendarID, input)
+	if err != nil {
+		return "", err
+	}
+	if conferenceLink != "" && details.Booking.ConferenceLink == "" {
+		details.Booking.ConferenceLink = conferenceLink
+	}
+	return eventID, nil
 }
 
 // CreateEventForHost creates a calendar event in a specific provider calendar.
-func (s *CalendarService) CreateEventForHost(ctx context.Context, details *BookingWithDetails, providerCalendarID string) (string, error) {
+// Returns (eventID, conferenceLink, error). conferenceLink is non-empty only
+// when Google Meet creation succeeded as part of the create call.
+func (s *CalendarService) CreateEventForHost(ctx context.Context, providerCalendarID string, input *CalendarEventInput) (string, string, error) {
 	if providerCalendarID == "" {
-		return "", nil
+		return "", "", nil
 	}
 
 	pc, err := s.repos.ProviderCalendar.GetByID(ctx, providerCalendarID)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if pc == nil {
-		return "", ErrCalendarNotFound
+		return "", "", ErrCalendarNotFound
 	}
 	if !pc.IsWritable {
-		return "", fmt.Errorf("calendar %s is not writable", pc.Name)
+		return "", "", fmt.Errorf("calendar %s is not writable", pc.Name)
 	}
 	conn, err := s.repos.Calendar.GetByID(ctx, pc.ConnectionID)
 	if err != nil || conn == nil {
-		return "", ErrCalendarNotFound
+		return "", "", ErrCalendarNotFound
 	}
 
 	view := *conn
 	switch conn.Provider {
 	case models.CalendarProviderGoogle:
 		view.CalendarID = pc.ProviderCalendarID
-		return s.createGoogleEvent(ctx, &view, details)
+		return s.createGoogleEvent(ctx, &view, input)
 	case models.CalendarProviderCalDAV, models.CalendarProviderICloud:
 		if pc.ProviderCalendarID != "" {
 			view.CalDAVURL = pc.ProviderCalendarID
 		}
-		return s.createCalDAVEvent(ctx, &view, details)
+		eventID, err := s.createCalDAVEvent(ctx, &view, input)
+		return eventID, "", err
 	}
-	return "", nil
+	return "", "", nil
 }
 
-// UpdateEvent updates an existing calendar event for a booking. If the booking
-// has no recorded event ID (e.g. event creation previously failed), falls back
-// to CreateEventForHost so reconnect-then-edit produces a fresh event.
+// UpdateEvent updates an existing calendar event. If input.EventID is empty
+// (e.g. event creation previously failed), falls back to CreateEventForHost so
+// reconnect-then-edit produces a fresh event — and the new event ID is
+// returned to the caller, which is responsible for persisting it.
 //
-// For Google: issues a PATCH so existing attendees keep their RSVP state and
-// get a single "event updated" invitation. For CalDAV: replaces the event via
-// delete + create (CalDAV does not have a clean PATCH primitive in this
-// codebase; the resulting iCal carries the new state to all attendees).
-func (s *CalendarService) UpdateEvent(ctx context.Context, details *BookingWithDetails, providerCalendarID string) (string, error) {
-	if details.Booking.CalendarEventID == "" {
-		return s.CreateEventForHost(ctx, details, providerCalendarID)
+// For Google: PATCH so existing attendees keep their RSVP state. For CalDAV:
+// replaces the event via delete + create; the new ID is returned and may
+// differ from input.EventID.
+func (s *CalendarService) UpdateEvent(ctx context.Context, providerCalendarID string, input *CalendarEventInput) (string, error) {
+	if input.EventID == "" {
+		eventID, _, err := s.CreateEventForHost(ctx, providerCalendarID, input)
+		return eventID, err
 	}
 	if providerCalendarID == "" {
-		return details.Booking.CalendarEventID, nil
+		return input.EventID, nil
 	}
 
 	pc, err := s.repos.ProviderCalendar.GetByID(ctx, providerCalendarID)
@@ -639,22 +738,21 @@ func (s *CalendarService) UpdateEvent(ctx context.Context, details *BookingWithD
 	switch conn.Provider {
 	case models.CalendarProviderGoogle:
 		view.CalendarID = pc.ProviderCalendarID
-		return s.updateGoogleEvent(ctx, &view, details)
+		return s.updateGoogleEvent(ctx, &view, input)
 	case models.CalendarProviderCalDAV, models.CalendarProviderICloud:
 		if pc.ProviderCalendarID != "" {
 			view.CalDAVURL = pc.ProviderCalendarID
 		}
-		// CalDAV: replace via delete + create.
-		if err := s.deleteCalDAVEvent(ctx, &view, details.Booking.CalendarEventID); err != nil {
+		if err := s.deleteCalDAVEvent(ctx, &view, input.EventID); err != nil {
 			log.Printf("[CALENDAR] CalDAV delete during update failed: %v", err)
 		}
-		newID, err := s.createCalDAVEvent(ctx, &view, details)
+		newID, err := s.createCalDAVEvent(ctx, &view, input)
 		if err != nil {
 			return "", err
 		}
 		return newID, nil
 	}
-	return details.Booking.CalendarEventID, nil
+	return input.EventID, nil
 }
 
 // DeleteEvent deletes a calendar event from a provider calendar.
@@ -992,71 +1090,50 @@ func (s *CalendarService) getGoogleBusyTimes(ctx context.Context, cal *models.Ca
 	return busyTimes, nil
 }
 
-func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.CalendarConnection, details *BookingWithDetails) (string, error) {
+func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.CalendarConnection, input *CalendarEventInput) (string, string, error) {
 	if err := s.refreshGoogleToken(cal); err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	// Build attendees list, filtering out invalid emails
-	attendees := []map[string]string{
-		{"email": details.Booking.InviteeEmail},
-	}
-	for _, guest := range details.Booking.AdditionalGuests {
-		// Basic email validation - must contain @ and have content on both sides
-		if strings.Contains(guest, "@") && len(strings.Split(guest, "@")[0]) > 0 && len(strings.Split(guest, "@")[1]) > 1 {
-			attendees = append(attendees, map[string]string{"email": guest})
+	attendees := make([]map[string]string, 0, len(input.Attendees))
+	for _, email := range input.Attendees {
+		if isValidEmail(email) {
+			attendees = append(attendees, map[string]string{"email": email})
 		}
 	}
-
-	// Build description with template description and agenda if provided
-	description := details.Template.Description
-	if details.Booking.Answers != nil {
-		if agenda, ok := details.Booking.Answers["agenda"].(string); ok && agenda != "" {
-			if description != "" {
-				description += "\n\n"
-			}
-			description += "Agenda:\n" + agenda
-		}
-	}
-
-	// Add reschedule link
-	rescheduleURL := fmt.Sprintf("%s/m/%s/%s/%s/reschedule/%s",
-		s.cfg.Server.BaseURL, details.Tenant.Slug, details.Host.Slug, details.Template.Slug, details.Booking.ID)
-	if description != "" {
-		description += "\n\n"
-	}
-	description += "Reschedule this meeting:\n" + rescheduleURL
 
 	event := map[string]interface{}{
-		"summary":     details.Template.Name + " with " + details.Booking.InviteeName,
-		"description": description,
+		"summary":     input.Summary,
+		"description": input.Description,
 		"start": map[string]string{
-			"dateTime": details.Booking.StartTime.Format(time.RFC3339),
+			"dateTime": input.Start.Format(time.RFC3339),
 			"timeZone": "UTC",
 		},
 		"end": map[string]string{
-			"dateTime": details.Booking.EndTime.Format(time.RFC3339),
+			"dateTime": input.End.Format(time.RFC3339),
 			"timeZone": "UTC",
 		},
 		"attendees": attendees,
 	}
 
-	// Add location based on location type
-	if details.Template.LocationType == models.ConferencingProviderPhone {
-		if details.Template.CustomLocation != "" {
-			event["location"] = "Call " + details.Template.CustomLocation
+	if input.LocationType == models.ConferencingProviderPhone {
+		if input.CustomLocation != "" {
+			event["location"] = "Call " + input.CustomLocation
 		}
-	} else if details.Booking.ConferenceLink != "" {
-		event["location"] = details.Booking.ConferenceLink
-	} else if details.Template.CustomLocation != "" {
-		event["location"] = details.Template.CustomLocation
+	} else if input.ConferenceLink != "" {
+		event["location"] = input.ConferenceLink
+	} else if input.CustomLocation != "" {
+		event["location"] = input.CustomLocation
 	}
 
-	// Add Google Meet if that's the location type and no link exists
-	if details.Template.LocationType == models.ConferencingProviderGoogleMeet && details.Booking.ConferenceLink == "" {
+	if input.LocationType == models.ConferencingProviderGoogleMeet && input.ConferenceLink == "" {
+		key := input.MeetIdempotencyKey
+		if key == "" {
+			key = uuid.New().String()
+		}
 		event["conferenceData"] = map[string]interface{}{
 			"createRequest": map[string]string{
-				"requestId": details.Booking.ID,
+				"requestId": key,
 			},
 		}
 	}
@@ -1070,7 +1147,7 @@ func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.Cal
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -1080,7 +1157,7 @@ func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.Cal
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("failed to create event: %s", string(respBody))
+		return "", "", fmt.Errorf("failed to create event: %s", string(respBody))
 	}
 
 	var result struct {
@@ -1092,68 +1169,44 @@ func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.Cal
 		} `json:"conferenceData"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	// Update conference link if Google Meet was created
-	if len(result.ConferenceData.EntryPoints) > 0 && details.Booking.ConferenceLink == "" {
-		details.Booking.ConferenceLink = result.ConferenceData.EntryPoints[0].URI
+	conferenceLink := ""
+	if len(result.ConferenceData.EntryPoints) > 0 && input.ConferenceLink == "" {
+		conferenceLink = result.ConferenceData.EntryPoints[0].URI
 	}
 
-	return result.ID, nil
+	return result.ID, conferenceLink, nil
 }
 
 // updateGoogleEvent PATCHes an existing Google Calendar event. The patch body
 // only includes mutable fields (description, location, attendees) — title and
 // time are left unchanged so this method composes safely with reschedule
 // (which deletes and recreates rather than patches).
-func (s *CalendarService) updateGoogleEvent(ctx context.Context, cal *models.CalendarConnection, details *BookingWithDetails) (string, error) {
+func (s *CalendarService) updateGoogleEvent(ctx context.Context, cal *models.CalendarConnection, input *CalendarEventInput) (string, error) {
 	if err := s.refreshGoogleToken(cal); err != nil {
 		return "", err
 	}
 
-	attendees := []map[string]string{
-		{"email": details.Booking.InviteeEmail},
-	}
-	for _, guest := range details.Booking.AdditionalGuests {
-		if strings.Contains(guest, "@") && len(strings.Split(guest, "@")[0]) > 0 && len(strings.Split(guest, "@")[1]) > 1 {
-			attendees = append(attendees, map[string]string{"email": guest})
+	attendees := make([]map[string]string, 0, len(input.Attendees))
+	for _, email := range input.Attendees {
+		if isValidEmail(email) {
+			attendees = append(attendees, map[string]string{"email": email})
 		}
 	}
-
-	description := details.Template.Description
-	if details.Booking.Answers != nil {
-		if agenda, ok := details.Booking.Answers["agenda"].(string); ok && agenda != "" {
-			if description != "" {
-				description += "\n\n"
-			}
-			description += "Agenda:\n" + agenda
-		}
-		if notes, ok := details.Booking.Answers["host_notes"].(string); ok && notes != "" {
-			if description != "" {
-				description += "\n\n"
-			}
-			description += "Notes from host:\n" + notes
-		}
-	}
-	rescheduleURL := fmt.Sprintf("%s/m/%s/%s/%s/reschedule/%s",
-		s.cfg.Server.BaseURL, details.Tenant.Slug, details.Host.Slug, details.Template.Slug, details.Booking.ID)
-	if description != "" {
-		description += "\n\n"
-	}
-	description += "Reschedule this meeting:\n" + rescheduleURL
 
 	patch := map[string]interface{}{
-		"description": description,
+		"description": input.Description,
 		"attendees":   attendees,
 	}
-	if details.Booking.ConferenceLink != "" {
-		patch["location"] = details.Booking.ConferenceLink
+	if input.ConferenceLink != "" {
+		patch["location"] = input.ConferenceLink
 	}
 
 	body, _ := json.Marshal(patch)
 	patchURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events/%s?sendUpdates=all",
-		url.PathEscape(cal.CalendarID), url.PathEscape(details.Booking.CalendarEventID))
+		url.PathEscape(cal.CalendarID), url.PathEscape(input.EventID))
 
 	req, _ := http.NewRequest("PATCH", patchURL, strings.NewReader(string(body)))
 	req.Header.Set("Authorization", "Bearer "+cal.AccessToken)
@@ -1174,7 +1227,7 @@ func (s *CalendarService) updateGoogleEvent(ctx context.Context, cal *models.Cal
 		return "", fmt.Errorf("failed to update event: %s", string(respBody))
 	}
 
-	return details.Booking.CalendarEventID, nil
+	return input.EventID, nil
 }
 
 func (s *CalendarService) deleteGoogleEvent(ctx context.Context, cal *models.CalendarConnection, eventID string) error {
@@ -1568,41 +1621,31 @@ func parseICSDuration(line string) (time.Duration, bool) {
 	return duration, duration > 0
 }
 
-func (s *CalendarService) createCalDAVEvent(ctx context.Context, cal *models.CalendarConnection, details *BookingWithDetails) (string, error) {
+func (s *CalendarService) createCalDAVEvent(ctx context.Context, cal *models.CalendarConnection, input *CalendarEventInput) (string, error) {
 	eventUID := uuid.New().String()
 
-	// Build location string
 	location := ""
-	if details.Template.LocationType == models.ConferencingProviderPhone {
-		if details.Template.CustomLocation != "" {
-			location = "Call " + details.Template.CustomLocation
+	if input.LocationType == models.ConferencingProviderPhone {
+		if input.CustomLocation != "" {
+			location = "Call " + input.CustomLocation
 		}
-	} else if details.Booking.ConferenceLink != "" {
-		location = details.Booking.ConferenceLink
-	} else if details.Template.CustomLocation != "" {
-		location = details.Template.CustomLocation
+	} else if input.ConferenceLink != "" {
+		location = input.ConferenceLink
+	} else if input.CustomLocation != "" {
+		location = input.CustomLocation
 	}
 
-	// Build description with template description and agenda if provided
-	description := details.Template.Description
-	if details.Booking.Answers != nil {
-		if agenda, ok := details.Booking.Answers["agenda"].(string); ok && agenda != "" {
-			if description != "" {
-				description += "\\n\\n"
-			}
-			description += "Agenda:\\n" + strings.ReplaceAll(agenda, "\n", "\\n")
+	// iCalendar requires literal "\n" sequences (escaped) in DESCRIPTION; the
+	// caller composes the description with real newlines, we escape here.
+	icsDescription := strings.ReplaceAll(input.Description, "\n", "\\n")
+
+	var attendeeLines string
+	for _, email := range input.Attendees {
+		if isValidEmail(email) {
+			attendeeLines += fmt.Sprintf("\nATTENDEE:mailto:%s", email)
 		}
 	}
 
-	// Add reschedule link
-	rescheduleURL := fmt.Sprintf("%s/m/%s/%s/%s/reschedule/%s",
-		s.cfg.Server.BaseURL, details.Tenant.Slug, details.Host.Slug, details.Template.Slug, details.Booking.ID)
-	if description != "" {
-		description += "\\n\\n"
-	}
-	description += "Reschedule this meeting:\\n" + rescheduleURL
-
-	// Build iCalendar event
 	ics := fmt.Sprintf(`BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//MeetWhen//EN
@@ -1613,18 +1656,17 @@ DTEND:%s
 SUMMARY:%s
 DESCRIPTION:%s
 LOCATION:%s
-ORGANIZER:mailto:%s
-ATTENDEE:mailto:%s
+ORGANIZER:mailto:%s%s
 END:VEVENT
 END:VCALENDAR`,
 		eventUID,
-		details.Booking.StartTime.UTC().Format("20060102T150405Z"),
-		details.Booking.EndTime.UTC().Format("20060102T150405Z"),
-		details.Template.Name+" with "+details.Booking.InviteeName,
-		description,
+		input.Start.UTC().Format("20060102T150405Z"),
+		input.End.UTC().Format("20060102T150405Z"),
+		input.Summary,
+		icsDescription,
 		location,
-		details.Host.Email,
-		details.Booking.InviteeEmail,
+		input.HostEmail,
+		attendeeLines,
 	)
 
 	eventURL := fmt.Sprintf("%s/%s.ics", strings.TrimSuffix(cal.CalDAVURL, "/"), eventUID)

--- a/internal/services/calendar_eventsync.go
+++ b/internal/services/calendar_eventsync.go
@@ -64,15 +64,15 @@ type CalendarEventSyncer struct {
 	stores   map[ScheduledItemKind]trackingStore
 }
 
-// NewCalendarEventSyncer constructs the syncer. Currently only the booking
-// kind is wired; the hosted-event kind is registered when its tracking
-// repository lands in Phase B.
+// NewCalendarEventSyncer constructs the syncer with both kind dispatchers
+// wired.
 func NewCalendarEventSyncer(repos *repository.Repositories, calendar calendarEventWriter) *CalendarEventSyncer {
 	return &CalendarEventSyncer{
 		repos:    repos,
 		calendar: calendar,
 		stores: map[ScheduledItemKind]trackingStore{
-			ItemKindBooking: &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+			ItemKindBooking:     &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+			ItemKindHostedEvent: &hostedEventTrackingStore{repo: repos.HostedEventCalendarEvent},
 		},
 	}
 }
@@ -268,4 +268,49 @@ func (b *bookingTrackingStore) updateEventID(ctx context.Context, rowID, newEven
 
 func (b *bookingTrackingStore) deleteByItemID(ctx context.Context, itemID string) error {
 	return b.repo.DeleteByBookingID(ctx, itemID)
+}
+
+// hostedEventTrackingStore adapts HostedEventCalendarEventRepository.
+type hostedEventTrackingStore struct {
+	repo *repository.HostedEventCalendarEventRepository
+}
+
+func (h *hostedEventTrackingStore) create(ctx context.Context, itemID, hostID, calendarID, eventID string) error {
+	return h.repo.Create(ctx, &models.HostedEventCalendarEvent{
+		ID:            uuid.New().String(),
+		HostedEventID: itemID,
+		HostID:        hostID,
+		CalendarID:    calendarID,
+		EventID:       eventID,
+		CreatedAt:     models.Now(),
+	})
+}
+
+func (h *hostedEventTrackingStore) listByItemID(ctx context.Context, itemID string) ([]trackingRow, error) {
+	events, err := h.repo.GetByHostedEventID(ctx, itemID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]trackingRow, 0, len(events))
+	for _, e := range events {
+		out = append(out, trackingRow{
+			ID:         e.ID,
+			HostID:     e.HostID,
+			CalendarID: e.CalendarID,
+			EventID:    e.EventID,
+		})
+	}
+	return out, nil
+}
+
+func (h *hostedEventTrackingStore) updateEventID(ctx context.Context, rowID, newEventID, newCalendarID string) error {
+	return h.repo.Update(ctx, &models.HostedEventCalendarEvent{
+		ID:         rowID,
+		EventID:    newEventID,
+		CalendarID: newCalendarID,
+	})
+}
+
+func (h *hostedEventTrackingStore) deleteByItemID(ctx context.Context, itemID string) error {
+	return h.repo.DeleteByHostedEventID(ctx, itemID)
 }

--- a/internal/services/calendar_eventsync.go
+++ b/internal/services/calendar_eventsync.go
@@ -1,0 +1,271 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/models"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// ScheduledItemKind identifies what kind of scheduled item a CalendarSyncRequest
+// belongs to. The syncer routes tracking-table writes off this value.
+type ScheduledItemKind string
+
+const (
+	ItemKindBooking     ScheduledItemKind = "booking"
+	ItemKindHostedEvent ScheduledItemKind = "hosted_event"
+)
+
+// HostTarget identifies one host's calendar that an event should be written to.
+type HostTarget struct {
+	HostID     string
+	CalendarID string // empty → resolve via host default + first writable
+	IsOwner    bool
+}
+
+// CalendarSyncRequest is the unified shape that BookingService and
+// HostedEventService hand to the syncer.
+type CalendarSyncRequest struct {
+	Kind   ScheduledItemKind
+	ItemID string
+	Input  CalendarEventInput
+	Hosts  []HostTarget
+}
+
+// trackingRow is the syncer's view of a row in either booking_calendar_events
+// or hosted_event_calendar_events. It's the minimum information the syncer
+// needs to update or delete provider events.
+type trackingRow struct {
+	ID         string
+	HostID     string
+	CalendarID string
+	EventID    string
+}
+
+// trackingStore abstracts the per-kind tracking table the syncer writes to.
+// One implementation per ScheduledItemKind.
+type trackingStore interface {
+	create(ctx context.Context, itemID, hostID, calendarID, eventID string) error
+	listByItemID(ctx context.Context, itemID string) ([]trackingRow, error)
+	updateEventID(ctx context.Context, rowID, newEventID, newCalendarID string) error
+	deleteByItemID(ctx context.Context, itemID string) error
+}
+
+// CalendarEventSyncer fans calendar create/update/delete out across one or
+// more host calendars and persists tracking rows. Replaces the duplicated
+// per-host logic that previously lived inside BookingService.
+type CalendarEventSyncer struct {
+	repos    *repository.Repositories
+	calendar calendarEventWriter
+	stores   map[ScheduledItemKind]trackingStore
+}
+
+// NewCalendarEventSyncer constructs the syncer. Currently only the booking
+// kind is wired; the hosted-event kind is registered when its tracking
+// repository lands in Phase B.
+func NewCalendarEventSyncer(repos *repository.Repositories, calendar calendarEventWriter) *CalendarEventSyncer {
+	return &CalendarEventSyncer{
+		repos:    repos,
+		calendar: calendar,
+		stores: map[ScheduledItemKind]trackingStore{
+			ItemKindBooking: &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+		},
+	}
+}
+
+// resolveWritableCalendarID returns the calendar ID to write to for a host:
+// preferredID if non-empty, else the host's default, else the first writable
+// provider calendar. Returns ("", error) only on lookup error; ("", nil) means
+// no writable calendar exists for this host (caller should skip).
+func (s *CalendarEventSyncer) resolveWritableCalendarID(ctx context.Context, hostID, preferredID string) (string, error) {
+	if preferredID != "" {
+		return preferredID, nil
+	}
+	host, err := s.repos.Host.GetByID(ctx, hostID)
+	if err != nil {
+		return "", err
+	}
+	if host != nil && host.DefaultCalendarID != nil && *host.DefaultCalendarID != "" {
+		return *host.DefaultCalendarID, nil
+	}
+	pcs, err := s.repos.ProviderCalendar.GetByHostID(ctx, hostID)
+	if err != nil {
+		return "", err
+	}
+	for _, pc := range pcs {
+		if pc.IsWritable {
+			return pc.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// Create writes the calendar event for every host target and persists one
+// tracking row per success. Returns the first non-empty event ID (used as the
+// "primary" ID by callers that keep a legacy single-event-id column) and the
+// first non-empty conference link surfaced by the create response (Google
+// Meet path). Per-host errors are logged but do not abort the batch — matches
+// the prior booking behaviour.
+func (s *CalendarEventSyncer) Create(ctx context.Context, req CalendarSyncRequest) (string, string, error) {
+	store, err := s.storeFor(req.Kind)
+	if err != nil {
+		return "", "", err
+	}
+
+	var firstEventID, firstConferenceLink string
+	for _, target := range req.Hosts {
+		calendarID, err := s.resolveWritableCalendarID(ctx, target.HostID, target.CalendarID)
+		if err != nil {
+			log.Printf("[SYNC] Error resolving calendar for host %s: %v", target.HostID, err)
+			continue
+		}
+		if calendarID == "" {
+			log.Printf("[SYNC] No writable calendar for host %s, skipping event creation", target.HostID)
+			continue
+		}
+
+		// The provider may need the per-host EventID empty (always for create).
+		input := req.Input
+		input.EventID = ""
+
+		eventID, conferenceLink, err := s.calendar.CreateEventForHost(ctx, calendarID, &input)
+		if err != nil {
+			log.Printf("[SYNC] Error creating calendar event for host %s: %v", target.HostID, err)
+			continue
+		}
+		if eventID == "" {
+			continue
+		}
+
+		if err := store.create(ctx, req.ItemID, target.HostID, calendarID, eventID); err != nil {
+			log.Printf("[SYNC] Error writing tracking row for %s/%s: %v", req.Kind, req.ItemID, err)
+		}
+
+		if firstEventID == "" && target.IsOwner {
+			firstEventID = eventID
+			firstConferenceLink = conferenceLink
+		} else if firstEventID == "" {
+			firstEventID = eventID
+			firstConferenceLink = conferenceLink
+		}
+	}
+	return firstEventID, firstConferenceLink, nil
+}
+
+// Update patches every tracked calendar event for the item. If a provider's
+// update returns a replacement event ID (CalDAV delete+create, or the
+// fallback-to-create path when the prior ID was empty), the tracking row is
+// updated in place — without this, subsequent updates / deletes would target
+// stale events.
+func (s *CalendarEventSyncer) Update(ctx context.Context, req CalendarSyncRequest) error {
+	store, err := s.storeFor(req.Kind)
+	if err != nil {
+		return err
+	}
+
+	rows, err := store.listByItemID(ctx, req.ItemID)
+	if err != nil {
+		return fmt.Errorf("list tracking rows: %w", err)
+	}
+
+	for _, row := range rows {
+		input := req.Input
+		input.EventID = row.EventID
+
+		newID, err := s.calendar.UpdateEvent(ctx, row.CalendarID, &input)
+		if err != nil {
+			log.Printf("[SYNC] Error updating calendar event %s for host %s: %v", row.EventID, row.HostID, err)
+			continue
+		}
+		if newID != "" && newID != row.EventID {
+			if err := store.updateEventID(ctx, row.ID, newID, row.CalendarID); err != nil {
+				log.Printf("[SYNC] Error persisting replacement event ID for %s/%s: %v", req.Kind, req.ItemID, err)
+			}
+		}
+	}
+	return nil
+}
+
+// Delete removes the calendar event for every host target and clears the
+// tracking rows. Returns the number of tracking rows that existed (callers
+// can branch on 0 to fall back to legacy single-host paths).
+func (s *CalendarEventSyncer) Delete(ctx context.Context, kind ScheduledItemKind, itemID string) (int, error) {
+	store, err := s.storeFor(kind)
+	if err != nil {
+		return 0, err
+	}
+
+	rows, err := store.listByItemID(ctx, itemID)
+	if err != nil {
+		return 0, fmt.Errorf("list tracking rows: %w", err)
+	}
+
+	for _, row := range rows {
+		if err := s.calendar.DeleteEvent(ctx, row.HostID, row.CalendarID, row.EventID); err != nil {
+			log.Printf("[SYNC] Error deleting calendar event %s for host %s: %v", row.EventID, row.HostID, err)
+		}
+	}
+	if len(rows) > 0 {
+		if err := store.deleteByItemID(ctx, itemID); err != nil {
+			log.Printf("[SYNC] Error clearing tracking rows for %s/%s: %v", kind, itemID, err)
+		}
+	}
+	return len(rows), nil
+}
+
+func (s *CalendarEventSyncer) storeFor(kind ScheduledItemKind) (trackingStore, error) {
+	store, ok := s.stores[kind]
+	if !ok {
+		return nil, errors.New("no tracking store registered for kind " + string(kind))
+	}
+	return store, nil
+}
+
+// bookingTrackingStore adapts BookingCalendarEventRepository to trackingStore.
+type bookingTrackingStore struct {
+	repo *repository.BookingCalendarEventRepository
+}
+
+func (b *bookingTrackingStore) create(ctx context.Context, itemID, hostID, calendarID, eventID string) error {
+	return b.repo.Create(ctx, &models.BookingCalendarEvent{
+		ID:         uuid.New().String(),
+		BookingID:  itemID,
+		HostID:     hostID,
+		CalendarID: calendarID,
+		EventID:    eventID,
+		CreatedAt:  models.Now(),
+	})
+}
+
+func (b *bookingTrackingStore) listByItemID(ctx context.Context, itemID string) ([]trackingRow, error) {
+	events, err := b.repo.GetByBookingID(ctx, itemID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]trackingRow, 0, len(events))
+	for _, e := range events {
+		out = append(out, trackingRow{
+			ID:         e.ID,
+			HostID:     e.HostID,
+			CalendarID: e.CalendarID,
+			EventID:    e.EventID,
+		})
+	}
+	return out, nil
+}
+
+func (b *bookingTrackingStore) updateEventID(ctx context.Context, rowID, newEventID, newCalendarID string) error {
+	return b.repo.Update(ctx, &models.BookingCalendarEvent{
+		ID:         rowID,
+		EventID:    newEventID,
+		CalendarID: newCalendarID,
+	})
+}
+
+func (b *bookingTrackingStore) deleteByItemID(ctx context.Context, itemID string) error {
+	return b.repo.DeleteByBookingID(ctx, itemID)
+}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -32,7 +32,8 @@ func New(cfg *config.Config, repos *repository.Repositories) *Services {
 	auditLogSvc := NewAuditLogService(repos)
 
 	contactSvc := NewContactService(repos)
-	bookingSvc := NewBookingService(cfg, repos, calendarSvc, conferencingSvc, emailSvc, auditLogSvc, contactSvc)
+	syncerSvc := NewCalendarEventSyncer(repos, calendarSvc)
+	bookingSvc := NewBookingService(cfg, repos, calendarSvc, syncerSvc, conferencingSvc, emailSvc, auditLogSvc, contactSvc)
 	templateSvc := NewTemplateService(repos, auditLogSvc)
 	sessionSvc := NewSessionService(cfg, repos)
 	authSvc := NewAuthService(cfg, repos, sessionSvc, auditLogSvc)

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -1,0 +1,44 @@
+package services
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/meet-when/meet-when/internal/config"
+	"github.com/meet-when/meet-when/internal/database"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// setupTestRepos opens an in-memory sqlite DB, applies all migrations, and
+// returns wired repositories. Used by service-level tests that need real
+// schema persistence (e.g. tracking-row writes in the syncer).
+func setupTestRepos(t *testing.T) (*sql.DB, *repository.Repositories, func()) {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	cfg := config.DatabaseConfig{
+		Driver:         "sqlite",
+		Name:           ":memory:",
+		MigrationsPath: cwd + "/../../migrations",
+	}
+
+	db, err := database.New(cfg)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := database.Migrate(db, cfg); err != nil {
+		_ = db.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+
+	cleanup := func() {
+		_ = db.Close()
+	}
+
+	return db, repository.NewRepositories(db, "sqlite"), cleanup
+}

--- a/migrations/014_add_hosted_events.down.sql
+++ b/migrations/014_add_hosted_events.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_hosted_event_calendar_events_item;
+DROP TABLE IF EXISTS hosted_event_calendar_events;
+DROP INDEX IF EXISTS idx_hosted_event_attendees_event;
+DROP TABLE IF EXISTS hosted_event_attendees;
+DROP INDEX IF EXISTS idx_hosted_events_tenant;
+DROP INDEX IF EXISTS idx_hosted_events_host_start;
+DROP TABLE IF EXISTS hosted_events;

--- a/migrations/014_add_hosted_events.up.sql
+++ b/migrations/014_add_hosted_events.up.sql
@@ -1,0 +1,49 @@
+-- Hosted events: host-driven scheduling (the inverse of bookings).
+CREATE TABLE hosted_events (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    host_id UUID NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    template_id UUID REFERENCES meeting_templates(id) ON DELETE SET NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    start_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    end_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    duration INTEGER NOT NULL,
+    timezone VARCHAR(100) NOT NULL DEFAULT 'UTC',
+    location_type VARCHAR(50) NOT NULL DEFAULT 'google_meet',
+    custom_location VARCHAR(500) NOT NULL DEFAULT '',
+    calendar_id VARCHAR(255) NOT NULL DEFAULT '',
+    conference_link VARCHAR(1000) NOT NULL DEFAULT '',
+    status VARCHAR(50) NOT NULL DEFAULT 'scheduled',
+    cancel_reason TEXT NOT NULL DEFAULT '',
+    reminder_sent BOOLEAN NOT NULL DEFAULT FALSE,
+    is_archived BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_hosted_events_host_start ON hosted_events(host_id, start_time);
+CREATE INDEX idx_hosted_events_tenant ON hosted_events(tenant_id);
+
+CREATE TABLE hosted_event_attendees (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    hosted_event_id UUID NOT NULL REFERENCES hosted_events(id) ON DELETE CASCADE,
+    email VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL DEFAULT '',
+    contact_id UUID REFERENCES contacts(id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE(hosted_event_id, email)
+);
+
+CREATE INDEX idx_hosted_event_attendees_event ON hosted_event_attendees(hosted_event_id);
+
+CREATE TABLE hosted_event_calendar_events (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    hosted_event_id UUID NOT NULL REFERENCES hosted_events(id) ON DELETE CASCADE,
+    host_id UUID NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    calendar_id UUID NOT NULL REFERENCES provider_calendars(id) ON DELETE CASCADE,
+    event_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_hosted_event_calendar_events_item ON hosted_event_calendar_events(hosted_event_id);

--- a/migrations/sqlite/014_add_hosted_events.down.sql
+++ b/migrations/sqlite/014_add_hosted_events.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_hosted_event_calendar_events_item;
+DROP TABLE IF EXISTS hosted_event_calendar_events;
+DROP INDEX IF EXISTS idx_hosted_event_attendees_event;
+DROP TABLE IF EXISTS hosted_event_attendees;
+DROP INDEX IF EXISTS idx_hosted_events_tenant;
+DROP INDEX IF EXISTS idx_hosted_events_host_start;
+DROP TABLE IF EXISTS hosted_events;

--- a/migrations/sqlite/014_add_hosted_events.up.sql
+++ b/migrations/sqlite/014_add_hosted_events.up.sql
@@ -1,0 +1,49 @@
+-- Hosted events: host-driven scheduling (the inverse of bookings).
+CREATE TABLE hosted_events (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    host_id TEXT NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    template_id TEXT REFERENCES meeting_templates(id) ON DELETE SET NULL,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    start_time TEXT NOT NULL,
+    end_time TEXT NOT NULL,
+    duration INTEGER NOT NULL,
+    timezone TEXT NOT NULL DEFAULT 'UTC',
+    location_type TEXT NOT NULL DEFAULT 'google_meet',
+    custom_location TEXT NOT NULL DEFAULT '',
+    calendar_id TEXT NOT NULL DEFAULT '',
+    conference_link TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'scheduled',
+    cancel_reason TEXT NOT NULL DEFAULT '',
+    reminder_sent INTEGER NOT NULL DEFAULT 0,
+    is_archived INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_hosted_events_host_start ON hosted_events(host_id, start_time);
+CREATE INDEX idx_hosted_events_tenant ON hosted_events(tenant_id);
+
+CREATE TABLE hosted_event_attendees (
+    id TEXT PRIMARY KEY,
+    hosted_event_id TEXT NOT NULL REFERENCES hosted_events(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    name TEXT NOT NULL DEFAULT '',
+    contact_id TEXT REFERENCES contacts(id) ON DELETE SET NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(hosted_event_id, email)
+);
+
+CREATE INDEX idx_hosted_event_attendees_event ON hosted_event_attendees(hosted_event_id);
+
+CREATE TABLE hosted_event_calendar_events (
+    id TEXT PRIMARY KEY,
+    hosted_event_id TEXT NOT NULL REFERENCES hosted_events(id) ON DELETE CASCADE,
+    host_id TEXT NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    calendar_id TEXT NOT NULL REFERENCES provider_calendars(id) ON DELETE CASCADE,
+    event_id TEXT NOT NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_hosted_event_calendar_events_item ON hosted_event_calendar_events(hosted_event_id);


### PR DESCRIPTION
## Summary
This PR introduces a unified calendar event synchronization layer (`CalendarEventSyncer`) that decouples calendar operations from booking/hosted-event business logic. It enables fan-out of calendar events across multiple host calendars while maintaining per-host tracking, replacing duplicated pooling logic previously embedded in `BookingService`.

## Key Changes

### New Components
- **`CalendarEventSyncer`** (`calendar_eventsync.go`): Unified syncer that handles create/update/delete operations across multiple host calendars with automatic tracking row persistence. Supports both bookings and hosted events via a `ScheduledItemKind` dispatch mechanism.
- **`CalendarEventInput`**: Provider-agnostic event shape that replaces the previous `BookingWithDetails` coupling. Callers build this once and hand it to the syncer for multi-host fan-out.
- **Hosted Events infrastructure**: New `HostedEvent`, `HostedEventAttendee`, and `HostedEventCalendarEvent` models with corresponding repositories and migrations. Enables host-driven scheduling (inverse of invitee-driven bookings).

### Refactored Calendar Service
- `CreateEventForHost()` and `UpdateEvent()` now accept `CalendarEventInput` instead of `BookingWithDetails`, removing booking-specific coupling
- New `BuildCalendarEventInputForBooking()` method composes the input (including description with agenda, notes, and reschedule link) that booking flows need
- `CreateEventForHost()` now returns `(eventID, conferenceLink, error)` to surface Google Meet links at creation time
- Extracted `calendarEventWriter` interface for testability

### BookingService Integration
- Delegates multi-host calendar operations to `CalendarEventSyncer` instead of inline pooling logic
- `deleteAllCalendarEvents()` and `updateAllCalendarEvents()` now use the syncer for tracked rows, with fallback to legacy single-host path for pre-refactor bookings
- Simplified error handling: per-host failures are logged but don't abort the batch (preserves prior behavior)

### Testing
- Comprehensive test suite for `CalendarEventSyncer` with fake calendar writer that records all calls and allows per-host error injection
- Test fixture infrastructure (`makeSyncerHarness`, `seedFixture`) for integration testing with real schema
- Tests verify: single/multi-host create, per-host failure resilience, conference link propagation, tracking row persistence

### Database
- New migrations for `hosted_events`, `hosted_event_attendees`, and `hosted_event_calendar_events` tables (both PostgreSQL and SQLite)
- Parallel structure to booking tables, enabling future hosted-event calendar sync

## Implementation Details
- Syncer resolves writable calendars via host default or first-writable fallback when `CalendarID` is empty
- Per-host errors are logged but don't prevent other hosts from being synced (matches prior booking behavior)
- Update operations preserve per-host event IDs and persist replacement IDs returned by providers (CalDAV delete+create path)
- Tracking store abstraction allows different table backends per `ScheduledItemKind` without duplicating sync logic

https://claude.ai/code/session_01YWosUoHN5qrc7bTrTv1hzM