### PR TITLE
feat(hosted-events): HostedEventService + email + reminder (Phase C + F)

### DIFF
--- a/internal/services/conferencing.go
+++ b/internal/services/conferencing.go
@@ -39,18 +39,35 @@ func NewConferencingService(cfg *config.Config, repos *repository.Repositories) 
 	}
 }
 
-// CreateMeeting creates a video conference meeting
+// CreateMeeting creates a video conference meeting for a booking. Kept on
+// the original signature; delegates to the booking-shape-agnostic raw helper
+// for the Zoom path so HostedEventService can reuse the same plumbing.
 func (s *ConferencingService) CreateMeeting(ctx context.Context, details *BookingWithDetails) (string, error) {
 	switch details.Template.LocationType {
 	case models.ConferencingProviderGoogleMeet:
 		// Google Meet is handled by calendar event creation
 		return "", nil
 	case models.ConferencingProviderZoom:
-		return s.createZoomMeeting(ctx, details)
+		topic := details.Template.Name + " with " + details.Booking.InviteeName
+		return s.createZoomMeetingRaw(ctx, details.Booking.HostID, topic, details.Booking.StartTime.Time, details.Booking.Duration)
 	case models.ConferencingProviderPhone:
 		return details.Template.CustomLocation, nil
 	case models.ConferencingProviderCustom:
 		return details.Template.CustomLocation, nil
+	}
+	return "", nil
+}
+
+// CreateMeetingForHostedEvent is the host-driven equivalent of CreateMeeting.
+// Returns the conference link (or "") for the requested location type.
+func (s *ConferencingService) CreateMeetingForHostedEvent(ctx context.Context, hostID, title string, start time.Time, durationMin int, locationType models.ConferencingProvider, customLocation string) (string, error) {
+	switch locationType {
+	case models.ConferencingProviderGoogleMeet:
+		return "", nil
+	case models.ConferencingProviderZoom:
+		return s.createZoomMeetingRaw(ctx, hostID, title, start, durationMin)
+	case models.ConferencingProviderPhone, models.ConferencingProviderCustom:
+		return customLocation, nil
 	}
 	return "", nil
 }
@@ -250,8 +267,10 @@ func (s *ConferencingService) refreshZoomToken(ctx context.Context, conn *models
 	return s.repos.Conferencing.Update(ctx, conn)
 }
 
-func (s *ConferencingService) createZoomMeeting(ctx context.Context, details *BookingWithDetails) (string, error) {
-	conn, err := s.repos.Conferencing.GetByHostAndProvider(ctx, details.Booking.HostID, models.ConferencingProviderZoom)
+// createZoomMeetingRaw is the shape-agnostic Zoom meeting creator. Used by
+// both booking and hosted-event flows. Returns the meeting join URL.
+func (s *ConferencingService) createZoomMeetingRaw(ctx context.Context, hostID, topic string, start time.Time, durationMin int) (string, error) {
+	conn, err := s.repos.Conferencing.GetByHostAndProvider(ctx, hostID, models.ConferencingProviderZoom)
 	if err != nil || conn == nil {
 		return "", ErrConferencingReauthRequired
 	}
@@ -261,10 +280,10 @@ func (s *ConferencingService) createZoomMeeting(ctx context.Context, details *Bo
 	}
 
 	meeting := map[string]interface{}{
-		"topic":      details.Template.Name + " with " + details.Booking.InviteeName,
+		"topic":      topic,
 		"type":       2, // Scheduled meeting
-		"start_time": details.Booking.StartTime.Format("2006-01-02T15:04:05Z"),
-		"duration":   details.Booking.Duration,
+		"start_time": start.UTC().Format("2006-01-02T15:04:05Z"),
+		"duration":   durationMin,
 		"timezone":   "UTC",
 		"settings": map[string]interface{}{
 			"host_video":        true,

--- a/internal/services/contact.go
+++ b/internal/services/contact.go
@@ -59,6 +59,32 @@ func (s *ContactService) UpsertFromBooking(ctx context.Context, details *Booking
 	}
 }
 
+// UpsertFromHostedEventAttendee creates or updates a contact from a hosted-
+// event attendee. The caller is expected to invoke this only for newly added
+// attendees on create / on update — not for retained attendees on edit, so
+// meeting_count and last_met don't get re-incremented from a benign edit.
+// Errors are logged but do not propagate, mirroring UpsertFromBooking.
+func (s *ContactService) UpsertFromHostedEventAttendee(ctx context.Context, tenantID string, email, name string, eventStart models.SQLiteTime) {
+	if tenantID == "" || email == "" {
+		return
+	}
+	now := models.Now()
+	contact := &models.Contact{
+		ID:           uuid.New().String(),
+		TenantID:     tenantID,
+		Name:         name,
+		Email:        email,
+		FirstMet:     &eventStart,
+		LastMet:      &eventStart,
+		MeetingCount: 1,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := s.repos.Contact.Upsert(ctx, contact); err != nil {
+		log.Printf("[CONTACT] Error upserting contact for %s: %v", email, err)
+	}
+}
+
 // BackfillFromBookings creates/updates contacts from all confirmed bookings for a tenant.
 func (s *ContactService) BackfillFromBookings(ctx context.Context, tenantID string) (int, error) {
 	bookings, err := s.repos.Booking.ListConfirmedByTenant(ctx, tenantID)
@@ -146,4 +172,3 @@ func (s *ContactService) EnsureBackfilled(ctx context.Context, tenantID string) 
 	}
 	return nil
 }
-

--- a/internal/services/email.go
+++ b/internal/services/email.go
@@ -914,6 +914,327 @@ func formatCancelReason(reason string) string {
 	return fmt.Sprintf("Reason: %s", reason)
 }
 
+// hostedEventTime returns the start time formatted in the event's timezone
+// (which is the host's perspective at scheduling time). Hosted-event attendees
+// don't carry a per-attendee tz today, so this is the best display choice.
+func hostedEventTime(event *models.HostedEvent) string {
+	loc, err := time.LoadLocation(event.Timezone)
+	if err != nil || loc == nil {
+		loc = time.UTC
+	}
+	return event.StartTime.In(loc).Format("Monday, January 2, 2006 at 3:04 PM MST")
+}
+
+// hostedEventLocationLabel returns the human-readable location for an event
+// (mirrors the per-LocationType branching in booking emails).
+func hostedEventLocationLabel(event *models.HostedEvent) string {
+	switch event.LocationType {
+	case models.ConferencingProviderPhone:
+		if event.CustomLocation != "" {
+			return "Call " + event.CustomLocation
+		}
+	case models.ConferencingProviderCustom:
+		if event.CustomLocation != "" {
+			return event.CustomLocation
+		}
+	}
+	if event.ConferenceLink != "" {
+		return event.ConferenceLink
+	}
+	if event.CustomLocation != "" {
+		return event.CustomLocation
+	}
+	return "To be determined"
+}
+
+// SendHostedEventInvited sends an invitation to a single attendee. Used both
+// at create time (every attendee) and on update when an attendee is added.
+func (s *EmailService) SendHostedEventInvited(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("%s invited you: %s", host.Name, event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	descriptionBlock := ""
+	if event.Description != "" {
+		descriptionBlock = fmt.Sprintf("\n%s\n", event.Description)
+	}
+
+	body := fmt.Sprintf(`%s,
+
+%s has scheduled a meeting with you:
+
+Meeting: %s
+When: %s
+Duration: %d minutes
+Location: %s
+%s
+This event has been added to your calendar. RSVP via your calendar app.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+		event.Duration,
+		hostedEventLocationLabel(event),
+		descriptionBlock,
+	)
+
+	ics := s.generateICSForHostedEvent(event, host, attendee, "REQUEST", "CONFIRMED")
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ics); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event invitation to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	// Notify the host as well, but only for create-time invitations the host
+	// will have a list of all attendees in their calendar — skip a per-host
+	// duplicate to avoid noise. (Mirrors booking flow which sends one host
+	// email per booking, not per guest.)
+	_ = tenant
+}
+
+// SendHostedEventUpdated notifies a retained attendee that material event
+// fields changed (time, title, location, etc.).
+func (s *EmailService) SendHostedEventUpdated(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant, changedFields []string) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("Updated: %s", event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	changedSummary := ""
+	if len(changedFields) > 0 {
+		changedSummary = fmt.Sprintf("\nWhat changed: %s\n", strings.Join(changedFields, ", "))
+	}
+
+	body := fmt.Sprintf(`%s,
+
+%s updated a meeting with you:
+
+Meeting: %s
+When: %s
+Duration: %d minutes
+Location: %s
+%s
+Your calendar has been updated automatically.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+		event.Duration,
+		hostedEventLocationLabel(event),
+		changedSummary,
+	)
+
+	ics := s.generateICSForHostedEvent(event, host, attendee, "REQUEST", "CONFIRMED")
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ics); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event update to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	_ = tenant
+}
+
+// SendHostedEventCancelled notifies an attendee that the entire event was
+// cancelled. The ICS is METHOD:CANCEL so calendar clients can remove it.
+func (s *EmailService) SendHostedEventCancelled(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("Cancelled: %s", event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	body := fmt.Sprintf(`%s,
+
+%s has cancelled this meeting:
+
+Meeting: %s
+Was scheduled for: %s
+
+%s
+
+The event has been removed from your calendar.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+		formatCancelReason(event.CancelReason),
+	)
+
+	ics := s.generateICSForHostedEvent(event, host, attendee, "CANCEL", "CANCELLED")
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ics); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event cancellation to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	_ = tenant
+}
+
+// SendHostedEventCancelledForAttendee notifies an attendee that they were
+// removed from an event that otherwise still goes ahead.
+func (s *EmailService) SendHostedEventCancelledForAttendee(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("You were removed from: %s", event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	body := fmt.Sprintf(`%s,
+
+%s has removed you from this meeting:
+
+Meeting: %s
+Was scheduled for: %s
+
+The event has been removed from your calendar.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+	)
+
+	// CANCEL ICS scoped to this attendee — removes only their copy.
+	ics := s.generateICSForHostedEvent(event, host, attendee, "CANCEL", "CANCELLED")
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ics); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event removal to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	_ = tenant
+}
+
+// SendHostedEventReminder sends a 24-hour reminder to a single attendee.
+func (s *EmailService) SendHostedEventReminder(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("Reminder: %s tomorrow", event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	body := fmt.Sprintf(`%s,
+
+This is a reminder of your upcoming meeting with %s:
+
+Meeting: %s
+When: %s
+Duration: %d minutes
+Location: %s
+
+See you tomorrow.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+		event.Duration,
+		hostedEventLocationLabel(event),
+	)
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ""); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event reminder to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	_ = tenant
+}
+
+// generateICSForHostedEvent emits an ICS payload for a hosted event addressed
+// to a single attendee. method is "REQUEST" for invites/updates or "CANCEL"
+// for cancellations; status is "CONFIRMED" or "CANCELLED" accordingly.
+func (s *EmailService) generateICSForHostedEvent(event *models.HostedEvent, host *models.Host, attendee *models.HostedEventAttendee, method, status string) string {
+	location := ""
+	switch event.LocationType {
+	case models.ConferencingProviderPhone:
+		if event.CustomLocation != "" {
+			location = "Call " + event.CustomLocation
+		}
+	default:
+		if event.ConferenceLink != "" {
+			location = event.ConferenceLink
+		} else if event.CustomLocation != "" {
+			location = event.CustomLocation
+		}
+	}
+
+	attendeeName := attendee.Name
+	if attendeeName == "" {
+		attendeeName = attendee.Email
+	}
+
+	return fmt.Sprintf(`BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//MeetWhen//EN
+METHOD:%s
+BEGIN:VEVENT
+UID:%s@meetwhen
+DTSTART:%s
+DTEND:%s
+SUMMARY:%s
+DESCRIPTION:%s
+LOCATION:%s
+ORGANIZER;CN=%s:mailto:%s
+ATTENDEE;CN=%s:mailto:%s
+STATUS:%s
+END:VEVENT
+END:VCALENDAR`,
+		method,
+		event.ID,
+		event.StartTime.UTC().Format("20060102T150405Z"),
+		event.EndTime.UTC().Format("20060102T150405Z"),
+		escapeICS(event.Title),
+		escapeICS(event.Description),
+		escapeICS(location),
+		host.Name,
+		host.Email,
+		attendeeName,
+		attendee.Email,
+		status,
+	)
+}
+
 func escapeICS(s string) string {
 	s = strings.ReplaceAll(s, "\\", "\\\\")
 	s = strings.ReplaceAll(s, ";", "\\;")

--- a/internal/services/hosted_event.go
+++ b/internal/services/hosted_event.go
@@ -1,0 +1,861 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/config"
+	"github.com/meet-when/meet-when/internal/models"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// AttendeeInput is the host-supplied attendee shape used by Create / Update
+// inputs. ContactID is non-nil when the attendee was picked from the contact
+// list, nil for free-form entries.
+type AttendeeInput struct {
+	Email     string
+	Name      string
+	ContactID *string
+}
+
+// CreateHostedEventInput is the host-supplied data needed to schedule a new
+// hosted event. Times are passed as time.Time and converted to SQLiteTime
+// internally.
+type CreateHostedEventInput struct {
+	HostID         string
+	TenantID       string
+	TemplateID     *string
+	Title          string
+	Description    string
+	Start          time.Time
+	Duration       int // minutes
+	Timezone       string
+	LocationType   models.ConferencingProvider
+	CustomLocation string
+	CalendarID     string
+	Attendees      []AttendeeInput
+}
+
+// UpdateHostedEventInput uses pointer fields for "change if non-nil"
+// semantics so the caller can express partial updates without ambiguity
+// between "no change" and "set to zero value".
+type UpdateHostedEventInput struct {
+	HostID                   string
+	TenantID                 string
+	EventID                  string
+	Title                    *string
+	Description              *string
+	CustomLocation           *string
+	Start                    *time.Time
+	Duration                 *int
+	Timezone                 *string
+	LocationType             *models.ConferencingProvider
+	CalendarID               *string
+	Attendees                *[]AttendeeInput
+	RegenerateConferenceLink bool
+}
+
+// HostedEventWithDetails bundles a hosted event with the joined entities
+// callers usually need (host, tenant, optional template, attendees).
+type HostedEventWithDetails struct {
+	Event     *models.HostedEvent
+	Host      *models.Host
+	Tenant    *models.Tenant
+	Template  *models.MeetingTemplate
+	Attendees []*models.HostedEventAttendee
+}
+
+// hostedEventEmailSender is the narrow surface HostedEventService needs from
+// the email layer. *EmailService satisfies it; tests inject a spy.
+type hostedEventEmailSender interface {
+	SendHostedEventInvited(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant)
+	SendHostedEventUpdated(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant, changedFields []string)
+	SendHostedEventCancelled(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant)
+	SendHostedEventCancelledForAttendee(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant)
+	SendHostedEventReminder(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant)
+}
+
+// HostedEventService orchestrates host-driven event scheduling. The shared
+// per-host calendar fan-out lives in CalendarEventSyncer (PR #43); this
+// service owns the entity-specific orchestration (validation, conferencing,
+// attendee diff, contact upsert, audit, email).
+type HostedEventService struct {
+	cfg          *config.Config
+	repos        *repository.Repositories
+	calendar     *CalendarService
+	conferencing *ConferencingService
+	syncer       *CalendarEventSyncer
+	email        hostedEventEmailSender
+	contact      *ContactService
+	audit        *AuditLogService
+}
+
+// NewHostedEventService constructs a HostedEventService.
+func NewHostedEventService(
+	cfg *config.Config,
+	repos *repository.Repositories,
+	calendar *CalendarService,
+	conferencing *ConferencingService,
+	syncer *CalendarEventSyncer,
+	email hostedEventEmailSender,
+	contact *ContactService,
+	audit *AuditLogService,
+) *HostedEventService {
+	return &HostedEventService{
+		cfg:          cfg,
+		repos:        repos,
+		calendar:     calendar,
+		conferencing: conferencing,
+		syncer:       syncer,
+		email:        email,
+		contact:      contact,
+		audit:        audit,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Read paths
+// ---------------------------------------------------------------------------
+
+// Get returns a hosted event with its joined details, scoped to the caller.
+// Returns (nil, nil) when not found; (nil, error) when the lookup itself
+// fails. Returns an error when the host/tenant scope mismatches.
+func (s *HostedEventService) Get(ctx context.Context, hostID, tenantID, eventID string) (*HostedEventWithDetails, error) {
+	event, err := s.repos.HostedEvent.GetByID(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+	if event == nil {
+		return nil, nil
+	}
+	if event.HostID != hostID || event.TenantID != tenantID {
+		return nil, errors.New("hosted event not found")
+	}
+	return s.loadDetails(ctx, event)
+}
+
+// List returns the host's hosted events ordered by start_time descending.
+func (s *HostedEventService) List(ctx context.Context, hostID string, includeArchived bool) ([]*models.HostedEvent, error) {
+	return s.repos.HostedEvent.ListByHost(ctx, hostID, includeArchived)
+}
+
+func (s *HostedEventService) loadDetails(ctx context.Context, event *models.HostedEvent) (*HostedEventWithDetails, error) {
+	host, err := s.repos.Host.GetByID(ctx, event.HostID)
+	if err != nil {
+		return nil, fmt.Errorf("load host: %w", err)
+	}
+	tenant, err := s.repos.Tenant.GetByID(ctx, event.TenantID)
+	if err != nil {
+		return nil, fmt.Errorf("load tenant: %w", err)
+	}
+	var template *models.MeetingTemplate
+	if event.TemplateID != nil && *event.TemplateID != "" {
+		template, _ = s.repos.Template.GetByID(ctx, *event.TemplateID) // best-effort
+	}
+	attendees, err := s.repos.HostedEventAttendee.ListByEvent(ctx, event.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load attendees: %w", err)
+	}
+	return &HostedEventWithDetails{
+		Event:     event,
+		Host:      host,
+		Tenant:    tenant,
+		Template:  template,
+		Attendees: attendees,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+// Create schedules a new hosted event:
+//  1. validates input
+//  2. resolves the calendar to write to
+//  3. persists the event + attendees in a tx
+//  4. creates a conferencing link if needed (best-effort; reauth-required
+//     surfaces but doesn't abort)
+//  5. fans out the calendar event via the syncer; the calendar layer may
+//     surface a conference link of its own (Google Meet) which is then
+//     persisted with a second write
+//  6. notifies attendees via email
+//  7. upserts contact rows for each attendee
+//  8. writes an audit entry
+func (s *HostedEventService) Create(ctx context.Context, input CreateHostedEventInput) (*HostedEventWithDetails, error) {
+	if err := s.validateCreate(input); err != nil {
+		return nil, err
+	}
+
+	host, err := s.repos.Host.GetByID(ctx, input.HostID)
+	if err != nil {
+		return nil, fmt.Errorf("load host: %w", err)
+	}
+	if host == nil || host.TenantID != input.TenantID {
+		return nil, errors.New("host not found")
+	}
+	tenant, err := s.repos.Tenant.GetByID(ctx, input.TenantID)
+	if err != nil || tenant == nil {
+		return nil, fmt.Errorf("load tenant: %w", err)
+	}
+
+	calendarID, err := s.resolveCalendarID(ctx, host, input.TemplateID, input.CalendarID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := models.Now()
+	end := input.Start.Add(time.Duration(input.Duration) * time.Minute)
+	tz := input.Timezone
+	if tz == "" {
+		tz = host.Timezone
+	}
+
+	event := &models.HostedEvent{
+		ID:             uuid.New().String(),
+		TenantID:       input.TenantID,
+		HostID:         input.HostID,
+		TemplateID:     input.TemplateID,
+		Title:          input.Title,
+		Description:    input.Description,
+		StartTime:      models.NewSQLiteTime(input.Start),
+		EndTime:        models.NewSQLiteTime(end),
+		Duration:       input.Duration,
+		Timezone:       tz,
+		LocationType:   input.LocationType,
+		CustomLocation: input.CustomLocation,
+		CalendarID:     calendarID,
+		Status:         models.HostedEventStatusScheduled,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	if err := s.repos.HostedEvent.Create(ctx, event); err != nil {
+		return nil, fmt.Errorf("persist event: %w", err)
+	}
+
+	attendees := s.buildAttendeeRows(event.ID, input.Attendees, now)
+	if err := s.repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, attendees); err != nil {
+		return nil, fmt.Errorf("persist attendees: %w", err)
+	}
+
+	// Conferencing — best-effort. ErrConferencingReauthRequired is logged
+	// but does not abort the event creation: the calendar event still goes
+	// out and the host can fix the conferencing link via retry.
+	if event.LocationType == models.ConferencingProviderZoom ||
+		event.LocationType == models.ConferencingProviderGoogleMeet ||
+		event.LocationType == models.ConferencingProviderPhone ||
+		event.LocationType == models.ConferencingProviderCustom {
+		link, err := s.conferencing.CreateMeetingForHostedEvent(ctx, host.ID, event.Title, event.StartTime.Time, event.Duration, event.LocationType, event.CustomLocation)
+		if err != nil {
+			if errors.Is(err, ErrConferencingReauthRequired) {
+				log.Printf("[HOSTED_EVENT] Conferencing reauth required for host %s on event %s; event will be created without a link", host.ID, event.ID)
+			} else {
+				log.Printf("[HOSTED_EVENT] Conferencing error for event %s: %v", event.ID, err)
+			}
+		} else if link != "" {
+			event.ConferenceLink = link
+		}
+	}
+
+	// Persist the conferencing-link write before fan-out so the calendar
+	// event carries the same link.
+	if event.ConferenceLink != "" {
+		event.UpdatedAt = models.Now()
+		if err := s.repos.HostedEvent.Update(ctx, event); err != nil {
+			log.Printf("[HOSTED_EVENT] Error persisting conference link on event %s: %v", event.ID, err)
+		}
+	}
+
+	// Calendar fan-out via the shared syncer. v1 hosted events have no
+	// pooled hosts — just the owner.
+	syncInput := s.buildCalendarEventInput(event, attendees, host, "" /* eventID empty for create */)
+	firstID, syncerLink, err := s.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindHostedEvent,
+		ItemID: event.ID,
+		Input:  syncInput,
+		Hosts:  []HostTarget{{HostID: host.ID, CalendarID: calendarID, IsOwner: true}},
+	})
+	if err != nil {
+		log.Printf("[HOSTED_EVENT] Syncer.Create error for event %s: %v", event.ID, err)
+	}
+	// Google Meet returns the link from the calendar create response; persist
+	// it (and the first event ID) — second write.
+	persistChanged := false
+	if syncerLink != "" && event.ConferenceLink == "" {
+		event.ConferenceLink = syncerLink
+		persistChanged = true
+	}
+	if persistChanged {
+		event.UpdatedAt = models.Now()
+		if err := s.repos.HostedEvent.Update(ctx, event); err != nil {
+			log.Printf("[HOSTED_EVENT] Error persisting post-sync link on event %s: %v", event.ID, err)
+		}
+	}
+	_ = firstID // tracked in hosted_event_calendar_events; not needed on the event row for v1
+
+	// Email each attendee.
+	for _, a := range attendees {
+		s.email.SendHostedEventInvited(ctx, event, a, host, tenant)
+	}
+
+	// Contact upsert for every attendee at create time (each attendee is
+	// "new" in the sense that this event is the first occurrence with them).
+	for _, a := range attendees {
+		s.contact.UpsertFromHostedEventAttendee(ctx, event.TenantID, a.Email, a.Name, event.StartTime)
+	}
+
+	hostID := host.ID
+	s.audit.Log(ctx, event.TenantID, &hostID, "hosted_event.created", "hosted_event", event.ID, models.JSONMap{
+		"title":     event.Title,
+		"start":     event.StartTime.UTC().Format(time.RFC3339),
+		"duration":  event.Duration,
+		"attendees": attendeeEmails(attendees),
+	}, "")
+
+	return &HostedEventWithDetails{
+		Event:     event,
+		Host:      host,
+		Tenant:    tenant,
+		Attendees: attendees,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+// Update applies a partial change to an existing event. Pointer fields on
+// UpdateHostedEventInput follow "change if non-nil" semantics. Returns the
+// updated details and the list of changed field names (for the audit entry
+// and email content).
+//
+// Behavioural notes:
+//   - When Start changes, reminder_sent is reset so the reminder loop fires
+//     against the new time.
+//   - Conferencing is regenerated only if RegenerateConferenceLink is set or
+//     LocationType changes — same shape as the booking flow.
+//   - Attendee diff is computed on lowercased email; added attendees get an
+//     "invited" email, removed get "cancelled-for-attendee", retained get
+//     an "updated" email iff a material field changed.
+//   - Contact upsert fires only for newly added attendees, so meeting_count
+//     and last_met don't get re-incremented on a benign edit.
+func (s *HostedEventService) Update(ctx context.Context, input UpdateHostedEventInput) (*HostedEventWithDetails, []string, error) {
+	if input.HostID == "" || input.TenantID == "" || input.EventID == "" {
+		return nil, nil, errors.New("host, tenant, and event ID are required")
+	}
+
+	details, err := s.Get(ctx, input.HostID, input.TenantID, input.EventID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if details == nil {
+		return nil, nil, errors.New("hosted event not found")
+	}
+	if details.Event.Status == models.HostedEventStatusCancelled {
+		return nil, nil, errors.New("cannot update a cancelled event")
+	}
+
+	event := details.Event
+	previousStart := event.StartTime
+	prevAttendees := details.Attendees
+
+	// ---- Field diff ----
+	changed := []string{}
+
+	if input.Title != nil && *input.Title != event.Title {
+		if strings.TrimSpace(*input.Title) == "" {
+			return nil, nil, errors.New("title cannot be empty")
+		}
+		event.Title = *input.Title
+		changed = append(changed, "title")
+	}
+	if input.Description != nil && *input.Description != event.Description {
+		event.Description = *input.Description
+		changed = append(changed, "description")
+	}
+	if input.CustomLocation != nil && *input.CustomLocation != event.CustomLocation {
+		event.CustomLocation = *input.CustomLocation
+		changed = append(changed, "custom_location")
+	}
+	if input.LocationType != nil && *input.LocationType != event.LocationType {
+		event.LocationType = *input.LocationType
+		changed = append(changed, "location_type")
+	}
+	if input.Timezone != nil && *input.Timezone != event.Timezone {
+		event.Timezone = *input.Timezone
+		changed = append(changed, "timezone")
+	}
+	if input.CalendarID != nil && *input.CalendarID != event.CalendarID {
+		event.CalendarID = *input.CalendarID
+		changed = append(changed, "calendar_id")
+	}
+
+	// Start / Duration changes ripple into EndTime.
+	startChanged := false
+	durationChanged := false
+	if input.Duration != nil && *input.Duration > 0 && *input.Duration != event.Duration {
+		event.Duration = *input.Duration
+		changed = append(changed, "duration")
+		durationChanged = true
+	}
+	if input.Start != nil && !input.Start.Equal(event.StartTime.Time) {
+		event.StartTime = models.NewSQLiteTime(*input.Start)
+		changed = append(changed, "start")
+		startChanged = true
+	}
+	if startChanged || durationChanged {
+		event.EndTime = models.NewSQLiteTime(event.StartTime.Time.Add(time.Duration(event.Duration) * time.Minute))
+	}
+
+	// ---- Attendee diff ----
+	addedAttendeeRows := []*models.HostedEventAttendee{}
+	removedAttendees := []*models.HostedEventAttendee{}
+	retainedAttendees := []*models.HostedEventAttendee{}
+	finalAttendees := prevAttendees
+
+	if input.Attendees != nil {
+		now := models.Now()
+		incoming := s.buildAttendeeRows(event.ID, *input.Attendees, now)
+		if len(incoming) == 0 {
+			return nil, nil, errors.New("at least one attendee is required")
+		}
+
+		prevByEmail := indexAttendeesByEmail(prevAttendees)
+		incomingByEmail := indexAttendeesByEmail(incoming)
+
+		for email, row := range incomingByEmail {
+			if existing, ok := prevByEmail[email]; ok {
+				// Retain — but inherit the prior row's ID and CreatedAt so the
+				// attendee history is preserved when ReplaceForEvent re-inserts.
+				row.ID = existing.ID
+				row.CreatedAt = existing.CreatedAt
+				retainedAttendees = append(retainedAttendees, row)
+			} else {
+				addedAttendeeRows = append(addedAttendeeRows, row)
+			}
+		}
+		for email, row := range prevByEmail {
+			if _, ok := incomingByEmail[email]; !ok {
+				removedAttendees = append(removedAttendees, row)
+			}
+		}
+
+		// Sort for deterministic order downstream (emails, audit detail).
+		sort.Slice(retainedAttendees, func(i, j int) bool { return retainedAttendees[i].Email < retainedAttendees[j].Email })
+		sort.Slice(addedAttendeeRows, func(i, j int) bool { return addedAttendeeRows[i].Email < addedAttendeeRows[j].Email })
+		sort.Slice(removedAttendees, func(i, j int) bool { return removedAttendees[i].Email < removedAttendees[j].Email })
+
+		finalAttendees = make([]*models.HostedEventAttendee, 0, len(retainedAttendees)+len(addedAttendeeRows))
+		finalAttendees = append(finalAttendees, retainedAttendees...)
+		finalAttendees = append(finalAttendees, addedAttendeeRows...)
+
+		if len(addedAttendeeRows) > 0 || len(removedAttendees) > 0 {
+			changed = append(changed, "attendees")
+		}
+	}
+
+	// Nothing changed — fast exit.
+	if len(changed) == 0 && !input.RegenerateConferenceLink {
+		return details, nil, nil
+	}
+
+	// ---- Conferencing regeneration ----
+	conferencingChanged := false
+	if input.RegenerateConferenceLink || sliceContains(changed, "location_type") {
+		link, err := s.conferencing.CreateMeetingForHostedEvent(ctx, details.Host.ID, event.Title, event.StartTime.Time, event.Duration, event.LocationType, event.CustomLocation)
+		if err != nil {
+			if errors.Is(err, ErrConferencingReauthRequired) {
+				return nil, nil, ErrConferencingReauthRequired
+			}
+			log.Printf("[HOSTED_EVENT] Conferencing error during update of event %s: %v", event.ID, err)
+		} else if link != event.ConferenceLink {
+			event.ConferenceLink = link
+			conferencingChanged = true
+		}
+	}
+	if conferencingChanged && !sliceContains(changed, "conference_link") {
+		changed = append(changed, "conference_link")
+	}
+
+	// ---- reminder_sent reset on time change ----
+	if startChanged && event.ReminderSent {
+		event.ReminderSent = false
+	}
+
+	// ---- Persist event + attendees ----
+	event.UpdatedAt = models.Now()
+	if err := s.repos.HostedEvent.Update(ctx, event); err != nil {
+		return nil, nil, fmt.Errorf("persist event update: %w", err)
+	}
+	if input.Attendees != nil {
+		if err := s.repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, finalAttendees); err != nil {
+			return nil, nil, fmt.Errorf("persist attendee update: %w", err)
+		}
+	}
+
+	// ---- Calendar fan-out (Update across all tracked rows) ----
+	syncInput := s.buildCalendarEventInput(event, finalAttendees, details.Host, "" /* per-row EventID is filled by syncer */)
+	if err := s.syncer.Update(ctx, CalendarSyncRequest{
+		Kind:   ItemKindHostedEvent,
+		ItemID: event.ID,
+		Input:  syncInput,
+		Hosts:  []HostTarget{{HostID: details.Host.ID, CalendarID: event.CalendarID, IsOwner: true}},
+	}); err != nil {
+		log.Printf("[HOSTED_EVENT] Syncer.Update error for event %s: %v", event.ID, err)
+	}
+
+	// ---- Email fan-out ----
+	materialChanged := hasMaterialChange(changed)
+	for _, a := range removedAttendees {
+		s.email.SendHostedEventCancelledForAttendee(ctx, event, a, details.Host, details.Tenant)
+	}
+	for _, a := range addedAttendeeRows {
+		s.email.SendHostedEventInvited(ctx, event, a, details.Host, details.Tenant)
+	}
+	if materialChanged {
+		for _, a := range retainedAttendees {
+			s.email.SendHostedEventUpdated(ctx, event, a, details.Host, details.Tenant, changed)
+		}
+	}
+
+	// ---- Contact upsert (added attendees only) ----
+	for _, a := range addedAttendeeRows {
+		s.contact.UpsertFromHostedEventAttendee(ctx, event.TenantID, a.Email, a.Name, event.StartTime)
+	}
+
+	// ---- Audit ----
+	hID := input.HostID
+	auditDetails := models.JSONMap{
+		"changed_fields": changed,
+	}
+	if startChanged {
+		auditDetails["previous_start"] = previousStart.UTC().Format(time.RFC3339)
+		auditDetails["new_start"] = event.StartTime.UTC().Format(time.RFC3339)
+	}
+	if len(addedAttendeeRows) > 0 {
+		auditDetails["added_attendees"] = attendeeEmails(addedAttendeeRows)
+	}
+	if len(removedAttendees) > 0 {
+		auditDetails["removed_attendees"] = attendeeEmails(removedAttendees)
+	}
+	s.audit.Log(ctx, event.TenantID, &hID, "hosted_event.updated", "hosted_event", event.ID, auditDetails, "")
+
+	out := &HostedEventWithDetails{
+		Event:     event,
+		Host:      details.Host,
+		Tenant:    details.Tenant,
+		Template:  details.Template,
+		Attendees: finalAttendees,
+	}
+	return out, changed, nil
+}
+
+// indexAttendeesByEmail returns a lowercase-email-keyed index of attendee
+// rows. Inputs from buildAttendeeRows are already lowercased; this is mostly
+// a defensive convenience for the existing-rows side.
+func indexAttendeesByEmail(rows []*models.HostedEventAttendee) map[string]*models.HostedEventAttendee {
+	out := make(map[string]*models.HostedEventAttendee, len(rows))
+	for _, r := range rows {
+		out[strings.ToLower(r.Email)] = r
+	}
+	return out
+}
+
+// hasMaterialChange returns true when any of the changed fields warrants
+// emailing retained attendees. "Calendar ID" alone is internal plumbing —
+// it doesn't change what the attendee sees.
+func hasMaterialChange(changed []string) bool {
+	for _, f := range changed {
+		switch f {
+		case "title", "description", "start", "duration", "location_type",
+			"custom_location", "conference_link", "timezone", "attendees":
+			return true
+		}
+	}
+	return false
+}
+
+func sliceContains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Cancel
+// ---------------------------------------------------------------------------
+
+// Cancel marks the event cancelled, removes it from every tracked host
+// calendar, emails attendees, and writes an audit entry.
+func (s *HostedEventService) Cancel(ctx context.Context, hostID, tenantID, eventID, reason string) error {
+	details, err := s.Get(ctx, hostID, tenantID, eventID)
+	if err != nil {
+		return err
+	}
+	if details == nil {
+		return errors.New("hosted event not found")
+	}
+	if details.Event.Status == models.HostedEventStatusCancelled {
+		return nil
+	}
+
+	details.Event.Status = models.HostedEventStatusCancelled
+	details.Event.CancelReason = reason
+	details.Event.UpdatedAt = models.Now()
+	if err := s.repos.HostedEvent.Update(ctx, details.Event); err != nil {
+		return fmt.Errorf("persist cancel: %w", err)
+	}
+
+	if _, err := s.syncer.Delete(ctx, ItemKindHostedEvent, eventID); err != nil {
+		log.Printf("[HOSTED_EVENT] Syncer.Delete error for event %s: %v", eventID, err)
+	}
+
+	for _, a := range details.Attendees {
+		s.email.SendHostedEventCancelled(ctx, details.Event, a, details.Host, details.Tenant)
+	}
+
+	hID := hostID
+	s.audit.Log(ctx, tenantID, &hID, "hosted_event.cancelled", "hosted_event", eventID, models.JSONMap{
+		"reason": reason,
+	}, "")
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Archive / Unarchive / Retry
+// ---------------------------------------------------------------------------
+
+// Archive marks the event archived (removes it from the default list view
+// without affecting calendar state).
+func (s *HostedEventService) Archive(ctx context.Context, hostID, tenantID, eventID string) error {
+	return s.toggleArchive(ctx, hostID, tenantID, eventID, true, "hosted_event.archived")
+}
+
+// Unarchive reverses Archive.
+func (s *HostedEventService) Unarchive(ctx context.Context, hostID, tenantID, eventID string) error {
+	return s.toggleArchive(ctx, hostID, tenantID, eventID, false, "hosted_event.unarchived")
+}
+
+func (s *HostedEventService) toggleArchive(ctx context.Context, hostID, tenantID, eventID string, archived bool, action string) error {
+	event, err := s.repos.HostedEvent.GetByID(ctx, eventID)
+	if err != nil {
+		return err
+	}
+	if event == nil || event.HostID != hostID || event.TenantID != tenantID {
+		return errors.New("hosted event not found")
+	}
+	if event.IsArchived == archived {
+		return nil
+	}
+	event.IsArchived = archived
+	event.UpdatedAt = models.Now()
+	if err := s.repos.HostedEvent.Update(ctx, event); err != nil {
+		return err
+	}
+	hID := hostID
+	s.audit.Log(ctx, tenantID, &hID, action, "hosted_event", eventID, nil, "")
+	return nil
+}
+
+// RetryCalendarEvent re-creates the calendar event for an event that has no
+// tracking rows (i.e. the original creation failed). Useful when the host
+// reconnects a calendar after the event was scheduled.
+func (s *HostedEventService) RetryCalendarEvent(ctx context.Context, hostID, tenantID, eventID string) error {
+	details, err := s.Get(ctx, hostID, tenantID, eventID)
+	if err != nil {
+		return err
+	}
+	if details == nil {
+		return errors.New("hosted event not found")
+	}
+	if details.Event.Status != models.HostedEventStatusScheduled {
+		return errors.New("only scheduled events can have calendar events retried")
+	}
+
+	syncInput := s.buildCalendarEventInput(details.Event, details.Attendees, details.Host, "")
+	if _, _, err := s.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindHostedEvent,
+		ItemID: details.Event.ID,
+		Input:  syncInput,
+		Hosts:  []HostTarget{{HostID: details.Host.ID, CalendarID: details.Event.CalendarID, IsOwner: true}},
+	}); err != nil {
+		return fmt.Errorf("syncer create: %w", err)
+	}
+
+	hID := hostID
+	s.audit.Log(ctx, tenantID, &hID, "hosted_event.calendar_retried", "hosted_event", eventID, nil, "")
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Conflict detection
+// ---------------------------------------------------------------------------
+
+// DetectBusyConflicts merges three sources to surface scheduling conflicts:
+// provider busy times, the host's confirmed bookings, and other hosted events.
+// excludeEventID skips an event from the hosted-events lookup so editing an
+// existing event doesn't report itself. Returns the overlapping windows; the
+// caller decides whether to warn or block (host-driven scheduling never
+// blocks — soft warning only).
+func (s *HostedEventService) DetectBusyConflicts(ctx context.Context, hostID string, start, end time.Time, excludeEventID string) ([]models.TimeSlot, error) {
+	var conflicts []models.TimeSlot
+
+	// Source 1: provider busy times.
+	busy, err := s.calendar.GetBusyTimes(ctx, hostID, start, end)
+	if err == nil {
+		for _, b := range busy {
+			if b.Start.Before(end) && b.End.After(start) {
+				conflicts = append(conflicts, b)
+			}
+		}
+	}
+
+	// Source 2: confirmed bookings in the window.
+	bookings, err := s.repos.Booking.GetByHostIDAndTimeRange(ctx, hostID, start, end)
+	if err == nil {
+		for _, b := range bookings {
+			if b.Status != models.BookingStatusConfirmed {
+				continue
+			}
+			conflicts = append(conflicts, models.TimeSlot{
+				Start: b.StartTime.Time,
+				End:   b.EndTime.Time,
+			})
+		}
+	}
+
+	// Source 3: other hosted events (scheduled status only; excluding self).
+	var exclude *string
+	if excludeEventID != "" {
+		exclude = &excludeEventID
+	}
+	others, err := s.repos.HostedEvent.GetByHostIDAndTimeRange(ctx, hostID, start, end, exclude)
+	if err == nil {
+		for _, o := range others {
+			conflicts = append(conflicts, models.TimeSlot{
+				Start: o.StartTime.Time,
+				End:   o.EndTime.Time,
+			})
+		}
+	}
+
+	// Sort for stable output.
+	sort.Slice(conflicts, func(i, j int) bool {
+		return conflicts[i].Start.Before(conflicts[j].Start)
+	})
+
+	return conflicts, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func (s *HostedEventService) validateCreate(input CreateHostedEventInput) error {
+	if strings.TrimSpace(input.Title) == "" {
+		return errors.New("title is required")
+	}
+	if input.Duration <= 0 {
+		return errors.New("duration must be positive")
+	}
+	if input.HostID == "" || input.TenantID == "" {
+		return errors.New("host and tenant are required")
+	}
+	if len(input.Attendees) == 0 {
+		return errors.New("at least one attendee is required")
+	}
+	for _, a := range input.Attendees {
+		if !isValidEmail(a.Email) {
+			return fmt.Errorf("invalid attendee email: %s", a.Email)
+		}
+	}
+	return nil
+}
+
+// resolveCalendarID picks the calendar to write to: explicit input → template
+// default → host default. Falls back to "" so the syncer's
+// resolveWritableCalendarID can pick the first writable provider calendar.
+func (s *HostedEventService) resolveCalendarID(ctx context.Context, host *models.Host, templateID *string, explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if templateID != nil && *templateID != "" {
+		template, err := s.repos.Template.GetByID(ctx, *templateID)
+		if err == nil && template != nil && template.CalendarID != "" {
+			return template.CalendarID, nil
+		}
+	}
+	if host.DefaultCalendarID != nil && *host.DefaultCalendarID != "" {
+		return *host.DefaultCalendarID, nil
+	}
+	return "", nil
+}
+
+// buildAttendeeRows converts AttendeeInputs into HostedEventAttendee rows.
+// Emails are lower-cased and de-duplicated (case-insensitive) so the unique
+// constraint on (hosted_event_id, email) is never tripped by minor user
+// inconsistencies.
+func (s *HostedEventService) buildAttendeeRows(eventID string, inputs []AttendeeInput, now models.SQLiteTime) []*models.HostedEventAttendee {
+	seen := make(map[string]bool, len(inputs))
+	out := make([]*models.HostedEventAttendee, 0, len(inputs))
+	for _, in := range inputs {
+		email := strings.ToLower(strings.TrimSpace(in.Email))
+		if email == "" || seen[email] {
+			continue
+		}
+		seen[email] = true
+		out = append(out, &models.HostedEventAttendee{
+			ID:            uuid.New().String(),
+			HostedEventID: eventID,
+			Email:         email,
+			Name:          strings.TrimSpace(in.Name),
+			ContactID:     in.ContactID,
+			CreatedAt:     now,
+		})
+	}
+	return out
+}
+
+// buildCalendarEventInput composes the provider-agnostic input the syncer
+// hands to the calendar layer. existingEventID is set on update flows so the
+// calendar provider patches in place; empty for create.
+func (s *HostedEventService) buildCalendarEventInput(event *models.HostedEvent, attendees []*models.HostedEventAttendee, host *models.Host, existingEventID string) CalendarEventInput {
+	emails := make([]string, 0, len(attendees))
+	for _, a := range attendees {
+		if a.Email != "" {
+			emails = append(emails, a.Email)
+		}
+	}
+	return CalendarEventInput{
+		Summary:            event.Title,
+		Description:        event.Description,
+		Start:              event.StartTime.Time,
+		End:                event.EndTime.Time,
+		LocationType:       event.LocationType,
+		CustomLocation:     event.CustomLocation,
+		ConferenceLink:     event.ConferenceLink,
+		Attendees:          emails,
+		HostName:           host.Name,
+		HostEmail:          host.Email,
+		EventID:            existingEventID,
+		MeetIdempotencyKey: event.ID,
+	}
+}
+
+func attendeeEmails(attendees []*models.HostedEventAttendee) []string {
+	out := make([]string, 0, len(attendees))
+	for _, a := range attendees {
+		out = append(out, a.Email)
+	}
+	return out
+}

--- a/internal/services/hosted_event_test.go
+++ b/internal/services/hosted_event_test.go
@@ -1,0 +1,699 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/config"
+	"github.com/meet-when/meet-when/internal/models"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+// spyEmailSender records every hosted-event email call. Concurrent-safe so
+// the goroutines inside SendHostedEventInvited et al don't race with the
+// test asserting on counts.
+type spyEmailSender struct {
+	mu sync.Mutex
+
+	invited          []emailCall
+	updated          []emailCall
+	cancelled        []emailCall
+	cancelledForAttn []emailCall
+	reminders        []emailCall
+}
+
+type emailCall struct {
+	EventID       string
+	AttendeeEmail string
+	ChangedFields []string
+}
+
+func (s *spyEmailSender) SendHostedEventInvited(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.invited = append(s.invited, emailCall{EventID: e.ID, AttendeeEmail: a.Email})
+}
+
+func (s *spyEmailSender) SendHostedEventUpdated(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant, changed []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.updated = append(s.updated, emailCall{EventID: e.ID, AttendeeEmail: a.Email, ChangedFields: append([]string(nil), changed...)})
+}
+
+func (s *spyEmailSender) SendHostedEventCancelled(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancelled = append(s.cancelled, emailCall{EventID: e.ID, AttendeeEmail: a.Email})
+}
+
+func (s *spyEmailSender) SendHostedEventCancelledForAttendee(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancelledForAttn = append(s.cancelledForAttn, emailCall{EventID: e.ID, AttendeeEmail: a.Email})
+}
+
+func (s *spyEmailSender) SendHostedEventReminder(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reminders = append(s.reminders, emailCall{EventID: e.ID, AttendeeEmail: a.Email})
+}
+
+// invitedEmails returns the set of attendee emails that received an invite.
+func (s *spyEmailSender) invitedEmails() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.invited))
+	for i, c := range s.invited {
+		out[i] = c.AttendeeEmail
+	}
+	return out
+}
+
+func (s *spyEmailSender) updatedCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.updated)
+}
+
+func (s *spyEmailSender) cancelledForAttendeeEmails() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.cancelledForAttn))
+	for i, c := range s.cancelledForAttn {
+		out[i] = c.AttendeeEmail
+	}
+	return out
+}
+
+func (s *spyEmailSender) cancelledEmails() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.cancelled))
+	for i, c := range s.cancelled {
+		out[i] = c.AttendeeEmail
+	}
+	return out
+}
+
+// hostedEventHarness wires HostedEventService against real repos + a fake
+// calendar writer + a spy email sender. Conferencing and contact run against
+// real services; conferencing without a Zoom connection naturally returns
+// ErrConferencingReauthRequired, which lets us cover the reauth path.
+type hostedEventHarness struct {
+	svc      *HostedEventService
+	syncer   *CalendarEventSyncer
+	repos    *repository.Repositories
+	fake     *fakeCalendarWriter
+	email    *spyEmailSender
+	host     *models.Host
+	tenant   *models.Tenant
+	template *models.MeetingTemplate
+	calID    string // primary writable calendar
+	cleanup  func()
+}
+
+func makeHostedEventHarness(t *testing.T) *hostedEventHarness {
+	t.Helper()
+	_, repos, cleanup := setupTestRepos(t)
+	ctx := context.Background()
+
+	tenant := &models.Tenant{
+		ID: uuid.New().String(), Slug: "tenant-" + uuid.New().String()[:6], Name: "Test Tenant",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Tenant.Create(ctx, tenant); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+
+	host := &models.Host{
+		ID: uuid.New().String(), TenantID: tenant.ID,
+		Email: "h-" + uuid.New().String()[:4] + "@example.com", PasswordHash: "x",
+		Name: "Test Host", Slug: "host-" + uuid.New().String()[:6],
+		Timezone: "UTC", CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Host.Create(ctx, host); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+
+	conn := &models.CalendarConnection{
+		ID: uuid.New().String(), HostID: host.ID,
+		Provider: models.CalendarProviderGoogle, Name: "primary-conn",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Calendar.Create(ctx, conn); err != nil {
+		t.Fatalf("create calendar connection: %v", err)
+	}
+	pc := &models.ProviderCalendar{
+		ID: uuid.New().String(), ConnectionID: conn.ID,
+		ProviderCalendarID: "primary", Name: "Primary", Color: "#000",
+		IsPrimary: true, IsWritable: true, PollBusy: true,
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.ProviderCalendar.Create(ctx, pc); err != nil {
+		t.Fatalf("create provider calendar: %v", err)
+	}
+
+	template := &models.MeetingTemplate{
+		ID: uuid.New().String(), HostID: host.ID,
+		Slug: "tmpl-" + uuid.New().String()[:6], Name: "Sales call",
+		Description: "Default template", Durations: models.IntSlice{30},
+		LocationType: models.ConferencingProviderGoogleMeet, CalendarID: pc.ID,
+		MaxScheduleDays: 30, IsActive: true,
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Template.Create(ctx, template); err != nil {
+		t.Fatalf("create template: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Server.BaseURL = "http://test.local"
+
+	calendarSvc := NewCalendarService(cfg, repos)
+	conferencingSvc := NewConferencingService(cfg, repos)
+	contactSvc := NewContactService(repos)
+	auditSvc := NewAuditLogService(repos)
+
+	fake := &fakeCalendarWriter{}
+	syncer := &CalendarEventSyncer{
+		repos:    repos,
+		calendar: fake,
+		stores: map[ScheduledItemKind]trackingStore{
+			ItemKindBooking:     &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+			ItemKindHostedEvent: &hostedEventTrackingStore{repo: repos.HostedEventCalendarEvent},
+		},
+	}
+
+	emailSpy := &spyEmailSender{}
+	svc := NewHostedEventService(cfg, repos, calendarSvc, conferencingSvc, syncer, emailSpy, contactSvc, auditSvc)
+
+	return &hostedEventHarness{
+		svc:      svc,
+		syncer:   syncer,
+		repos:    repos,
+		fake:     fake,
+		email:    emailSpy,
+		host:     host,
+		tenant:   tenant,
+		template: template,
+		calID:    pc.ID,
+		cleanup:  cleanup,
+	}
+}
+
+func (h *hostedEventHarness) baseCreateInput() CreateHostedEventInput {
+	return CreateHostedEventInput{
+		HostID:       h.host.ID,
+		TenantID:     h.tenant.ID,
+		Title:        "Quarterly review",
+		Description:  "What we shipped, what's next.",
+		Start:        time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC),
+		Duration:     30,
+		Timezone:     "UTC",
+		LocationType: models.ConferencingProviderGoogleMeet,
+		CalendarID:   h.calID,
+		Attendees: []AttendeeInput{
+			{Email: "alice@example.com", Name: "Alice"},
+			{Email: "bob@example.com", Name: "Bob"},
+		},
+	}
+}
+
+// waitForEmails spins until the spy reports the expected count, with a
+// generous timeout to absorb the goroutines launched by EmailService-style
+// senders. Our spy is synchronous, so this is effectively immediate, but the
+// helper keeps tests robust against future async drift.
+func (h *hostedEventHarness) waitForInvited(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(h.email.invitedEmails()) >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("expected %d invited emails, got %d", want, len(h.email.invitedEmails()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestHostedEventCreate_PersistsEventAndAttendees(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	out, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create returned err: %v", err)
+	}
+	if out == nil || out.Event == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if out.Event.Status != models.HostedEventStatusScheduled {
+		t.Fatalf("status = %q, want scheduled", out.Event.Status)
+	}
+	if out.Event.EndTime.Sub(out.Event.StartTime.Time) != 30*time.Minute {
+		t.Fatalf("end - start = %v, want 30m", out.Event.EndTime.Sub(out.Event.StartTime.Time))
+	}
+	persisted, err := h.repos.HostedEvent.GetByID(ctx, out.Event.ID)
+	if err != nil || persisted == nil {
+		t.Fatalf("persisted lookup: %v / %v", err, persisted)
+	}
+
+	attendees, err := h.repos.HostedEventAttendee.ListByEvent(ctx, out.Event.ID)
+	if err != nil {
+		t.Fatalf("ListByEvent: %v", err)
+	}
+	if len(attendees) != 2 {
+		t.Fatalf("expected 2 attendee rows, got %d", len(attendees))
+	}
+	if attendees[0].Email != "alice@example.com" || attendees[1].Email != "bob@example.com" {
+		t.Fatalf("attendee emails = %s, %s", attendees[0].Email, attendees[1].Email)
+	}
+}
+
+func TestHostedEventCreate_ResolvesCalendarFromExplicit(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	out, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.Event.CalendarID != h.calID {
+		t.Fatalf("explicit calendar not preserved: got %q, want %q", out.Event.CalendarID, h.calID)
+	}
+}
+
+func TestHostedEventCreate_ResolvesCalendarFromTemplateThenHost(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	// No explicit calendar. Template has CalendarID set; expect that.
+	in := h.baseCreateInput()
+	in.CalendarID = ""
+	tmplID := h.template.ID
+	in.TemplateID = &tmplID
+	out, err := h.svc.Create(ctx, in)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.Event.CalendarID != h.template.CalendarID {
+		t.Fatalf("template calendar not used: got %q, want %q", out.Event.CalendarID, h.template.CalendarID)
+	}
+
+	// No template either, but host has a default calendar.
+	defaultCal := h.calID
+	h.host.DefaultCalendarID = &defaultCal
+	if err := h.repos.Host.Update(ctx, h.host); err != nil {
+		t.Fatalf("update host: %v", err)
+	}
+	in2 := h.baseCreateInput()
+	in2.CalendarID = ""
+	in2.TemplateID = nil
+	out2, err := h.svc.Create(ctx, in2)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out2.Event.CalendarID != defaultCal {
+		t.Fatalf("host default calendar not used: got %q, want %q", out2.Event.CalendarID, defaultCal)
+	}
+}
+
+func TestHostedEventCreate_ConferencingReauthRequired_StillPersistsEvent(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	// Zoom location type without any Zoom OAuth connection seeded.
+	in := h.baseCreateInput()
+	in.LocationType = models.ConferencingProviderZoom
+	out, err := h.svc.Create(ctx, in)
+	if err != nil {
+		t.Fatalf("Create returned err (should swallow reauth-required on create): %v", err)
+	}
+	if out == nil || out.Event == nil {
+		t.Fatal("expected event to be persisted despite missing Zoom connection")
+	}
+	persisted, _ := h.repos.HostedEvent.GetByID(ctx, out.Event.ID)
+	if persisted == nil {
+		t.Fatal("event row missing after reauth-required path")
+	}
+	if persisted.ConferenceLink != "" {
+		t.Fatalf("conference link should be empty when conferencing fails; got %q", persisted.ConferenceLink)
+	}
+}
+
+func TestHostedEventCreate_GoogleMeet_LinkFromSyncerPersisted(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	// Simulate Google Meet returning a conference link via the calendar
+	// create response (the second-write path).
+	h.fake.nextCreate = []fakeCreateResult{{
+		EventID: "calendar-evt-1", ConferenceLink: "https://meet.google.com/zzz-aaa-bbb",
+	}}
+
+	out, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	persisted, _ := h.repos.HostedEvent.GetByID(ctx, out.Event.ID)
+	if persisted == nil {
+		t.Fatal("event missing")
+	}
+	if persisted.ConferenceLink != "https://meet.google.com/zzz-aaa-bbb" {
+		t.Fatalf("syncer-returned conference link not persisted: got %q", persisted.ConferenceLink)
+	}
+}
+
+func TestHostedEventCreate_SendsInvitedEmailToEachAttendee(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	if _, err := h.svc.Create(ctx, h.baseCreateInput()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.waitForInvited(t, 2)
+	got := h.email.invitedEmails()
+	if !contains(got, "alice@example.com") || !contains(got, "bob@example.com") {
+		t.Fatalf("invited recipients = %v, missing one of alice/bob", got)
+	}
+}
+
+func TestHostedEventCreate_UpsertsContactsForAttendees(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	if _, err := h.svc.Create(ctx, h.baseCreateInput()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Contact upsert is fire-and-forget but synchronous to the repo write
+	// inside ContactService.UpsertFromHostedEventAttendee. Allow a small
+	// settle window.
+	time.Sleep(20 * time.Millisecond)
+
+	c1, err := h.repos.Contact.GetByEmail(ctx, h.tenant.ID, "alice@example.com")
+	if err != nil {
+		t.Fatalf("get contact alice: %v", err)
+	}
+	if c1 == nil {
+		t.Fatal("expected contact for alice@example.com to be upserted")
+	}
+}
+
+func TestHostedEventUpdate_AttendeeDiff_RoutesEmailsCorrectly(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.waitForInvited(t, 2)
+
+	// Reset the spy so we only see the update-time emails.
+	h.email = &spyEmailSender{}
+	h.svc.email = h.email
+
+	// Bob removed, Carol added, Alice retained.
+	newAttendees := []AttendeeInput{
+		{Email: "alice@example.com", Name: "Alice"},
+		{Email: "carol@example.com", Name: "Carol"},
+	}
+	newTitle := "Quarterly review (updated)"
+	if _, _, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID:    h.host.ID,
+		TenantID:  h.tenant.ID,
+		EventID:   created.Event.ID,
+		Title:     &newTitle,
+		Attendees: &newAttendees,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Expect: 1 invited (Carol), 1 cancelled-for-attendee (Bob),
+	// 1 updated (Alice retained, title changed).
+	time.Sleep(30 * time.Millisecond)
+
+	if got := h.email.invitedEmails(); !equalSet(got, []string{"carol@example.com"}) {
+		t.Fatalf("invited = %v, want [carol]", got)
+	}
+	if got := h.email.cancelledForAttendeeEmails(); !equalSet(got, []string{"bob@example.com"}) {
+		t.Fatalf("cancelled-for-attendee = %v, want [bob]", got)
+	}
+	if h.email.updatedCount() != 1 {
+		t.Fatalf("expected 1 updated email (alice retained), got %d", h.email.updatedCount())
+	}
+}
+
+func TestHostedEventUpdate_TimeChange_ResetsReminderSent(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Mark reminder as already sent.
+	if err := h.repos.HostedEvent.MarkReminderSent(ctx, created.Event.ID); err != nil {
+		t.Fatalf("MarkReminderSent: %v", err)
+	}
+	pre, _ := h.repos.HostedEvent.GetByID(ctx, created.Event.ID)
+	if !pre.ReminderSent {
+		t.Fatal("precondition: reminder_sent should be true after MarkReminderSent")
+	}
+
+	newStart := created.Event.StartTime.Add(2 * time.Hour)
+	if _, _, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID:   h.host.ID,
+		TenantID: h.tenant.ID,
+		EventID:  created.Event.ID,
+		Start:    &newStart,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	post, _ := h.repos.HostedEvent.GetByID(ctx, created.Event.ID)
+	if post.ReminderSent {
+		t.Fatal("reminder_sent should reset to false after Start change")
+	}
+}
+
+func TestHostedEventUpdate_NoMaterialChange_SendsNoEmail(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.waitForInvited(t, 2)
+	h.email = &spyEmailSender{}
+	h.svc.email = h.email
+
+	// Update with no actual changes.
+	sameTitle := created.Event.Title
+	if _, changed, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID:   h.host.ID,
+		TenantID: h.tenant.ID,
+		EventID:  created.Event.ID,
+		Title:    &sameTitle,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	} else if len(changed) != 0 {
+		t.Fatalf("expected no changed fields, got %v", changed)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	if h.email.updatedCount() != 0 || len(h.email.invitedEmails()) != 0 {
+		t.Fatalf("no-op update should send no email; updated=%d invited=%d",
+			h.email.updatedCount(), len(h.email.invitedEmails()))
+	}
+}
+
+func TestHostedEventUpdate_PatchesAllTrackedCalendarEvents(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// One tracking row for the owner.
+	rows, _ := h.repos.HostedEventCalendarEvent.GetByHostedEventID(ctx, created.Event.ID)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 tracking row after create, got %d", len(rows))
+	}
+	h.fake.updateCalls = nil
+
+	newTitle := "Renamed"
+	if _, _, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID: h.host.ID, TenantID: h.tenant.ID, EventID: created.Event.ID,
+		Title: &newTitle,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := len(h.fake.updateCalls); got != 1 {
+		t.Fatalf("expected 1 calendar update call, got %d", got)
+	}
+}
+
+func TestHostedEventUpdate_ContactNotReupsertedForRetained(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	preAlice, _ := h.repos.Contact.GetByEmail(ctx, h.tenant.ID, "alice@example.com")
+	if preAlice == nil {
+		t.Fatal("alice contact missing after create")
+	}
+	preCount := preAlice.MeetingCount
+
+	// Update title only, keep both attendees. No new contact upsert should
+	// run for either retained attendee.
+	newTitle := "Renamed"
+	sameAttendees := []AttendeeInput{
+		{Email: "alice@example.com", Name: "Alice"},
+		{Email: "bob@example.com", Name: "Bob"},
+	}
+	if _, _, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID: h.host.ID, TenantID: h.tenant.ID, EventID: created.Event.ID,
+		Title: &newTitle, Attendees: &sameAttendees,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	postAlice, _ := h.repos.Contact.GetByEmail(ctx, h.tenant.ID, "alice@example.com")
+	if postAlice == nil {
+		t.Fatal("alice contact disappeared")
+	}
+	if postAlice.MeetingCount != preCount {
+		t.Fatalf("retained attendee meeting_count was re-incremented: %d → %d", preCount, postAlice.MeetingCount)
+	}
+}
+
+func TestHostedEventCancel_DeletesTrackedRowsAndEmails(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.waitForInvited(t, 2)
+
+	if err := h.svc.Cancel(ctx, h.host.ID, h.tenant.ID, created.Event.ID, "no longer needed"); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	rows, _ := h.repos.HostedEventCalendarEvent.GetByHostedEventID(ctx, created.Event.ID)
+	if len(rows) != 0 {
+		t.Fatalf("expected 0 tracking rows after cancel, got %d", len(rows))
+	}
+	persisted, _ := h.repos.HostedEvent.GetByID(ctx, created.Event.ID)
+	if persisted.Status != models.HostedEventStatusCancelled {
+		t.Fatalf("status = %q, want cancelled", persisted.Status)
+	}
+	if persisted.CancelReason != "no longer needed" {
+		t.Fatalf("cancel reason = %q", persisted.CancelReason)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := h.email.cancelledEmails(); !equalSet(got, []string{"alice@example.com", "bob@example.com"}) {
+		t.Fatalf("cancelled emails = %v, want [alice, bob]", got)
+	}
+}
+
+func TestHostedEventDetectBusyConflicts_ExcludesSelf(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Same window, excluding the event itself → no hosted-event conflict.
+	start := created.Event.StartTime.Time
+	end := created.Event.EndTime.Time
+	conflicts, err := h.svc.DetectBusyConflicts(ctx, h.host.ID, start, end, created.Event.ID)
+	if err != nil {
+		t.Fatalf("DetectBusyConflicts: %v", err)
+	}
+	for _, c := range conflicts {
+		if c.Start.Equal(start) && c.End.Equal(end) {
+			t.Fatalf("self-event reported as conflict; should be excluded")
+		}
+	}
+
+	// Without exclusion, the event itself shows up.
+	conflicts2, err := h.svc.DetectBusyConflicts(ctx, h.host.ID, start, end, "")
+	if err != nil {
+		t.Fatalf("DetectBusyConflicts (no exclude): %v", err)
+	}
+	hit := false
+	for _, c := range conflicts2 {
+		if c.Start.Equal(start) && c.End.Equal(end) {
+			hit = true
+		}
+	}
+	if !hit {
+		t.Fatalf("expected hosted event to surface in own-window conflict scan, got none")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Small assertion helpers
+// ---------------------------------------------------------------------------
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func equalSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	mb := make(map[string]int, len(b))
+	for _, v := range b {
+		mb[v]++
+	}
+	for _, v := range a {
+		if mb[v] == 0 {
+			return false
+		}
+		mb[v]--
+	}
+	return true
+}

--- a/internal/services/reminder.go
+++ b/internal/services/reminder.go
@@ -61,23 +61,28 @@ func (s *ReminderService) run() {
 	}
 }
 
-// checkAndSendReminders finds bookings that need reminders and sends them
+// checkAndSendReminders finds bookings and hosted events that need reminders
+// and sends them. Booking and hosted-event sources are processed in separate
+// sub-funcs so a partial failure in one source does not abort the other.
 func (s *ReminderService) checkAndSendReminders() {
 	ctx := context.Background()
 
-	// Find confirmed bookings starting in the next 24-25 hours that haven't had reminders sent
-	// We use a 1-hour window (24-25 hours) to ensure we don't miss any bookings
-	// and don't send reminders too early
+	// Window: 23-25 hours from now (1-hour cushion either side of "tomorrow"
+	// so we don't miss any items between ticks).
 	now := time.Now().UTC()
-	reminderWindowStart := now.Add(23 * time.Hour) // Start checking 23 hours from now
-	reminderWindowEnd := now.Add(25 * time.Hour)   // Up to 25 hours from now
+	windowStart := now.Add(23 * time.Hour)
+	windowEnd := now.Add(25 * time.Hour)
 
-	bookings, err := s.repos.Booking.GetBookingsNeedingReminder(ctx, reminderWindowStart, reminderWindowEnd)
+	s.processBookingReminders(ctx, windowStart, windowEnd)
+	s.processHostedEventReminders(ctx, windowStart, windowEnd)
+}
+
+func (s *ReminderService) processBookingReminders(ctx context.Context, windowStart, windowEnd time.Time) {
+	bookings, err := s.repos.Booking.GetBookingsNeedingReminder(ctx, windowStart, windowEnd)
 	if err != nil {
 		log.Printf("[REMINDER] Error fetching bookings needing reminders: %v", err)
 		return
 	}
-
 	if len(bookings) == 0 {
 		return
 	}
@@ -85,7 +90,6 @@ func (s *ReminderService) checkAndSendReminders() {
 	log.Printf("[REMINDER] Found %d bookings needing reminders", len(bookings))
 
 	for _, booking := range bookings {
-		// Get related entities
 		template, err := s.repos.Template.GetByID(ctx, booking.TemplateID)
 		if err != nil || template == nil {
 			log.Printf("[REMINDER] Error fetching template %s: %v", booking.TemplateID, err)
@@ -111,15 +115,55 @@ func (s *ReminderService) checkAndSendReminders() {
 			Tenant:   tenant,
 		}
 
-		// Send the reminder email
 		s.email.SendBookingReminder(ctx, details)
 
-		// Mark the reminder as sent
 		if err := s.repos.Booking.MarkReminderSent(ctx, booking.ID); err != nil {
 			log.Printf("[REMINDER] Error marking reminder sent for booking %s: %v", booking.ID, err)
 		} else {
 			log.Printf("[REMINDER] Sent reminder for booking %s (invitee: %s, meeting: %s at %s)",
 				booking.ID, booking.InviteeEmail, template.Name, booking.StartTime.Format(time.RFC3339))
+		}
+	}
+}
+
+func (s *ReminderService) processHostedEventReminders(ctx context.Context, windowStart, windowEnd time.Time) {
+	events, err := s.repos.HostedEvent.GetUpcomingForReminders(ctx, windowStart, windowEnd)
+	if err != nil {
+		log.Printf("[REMINDER] Error fetching hosted events needing reminders: %v", err)
+		return
+	}
+	if len(events) == 0 {
+		return
+	}
+
+	log.Printf("[REMINDER] Found %d hosted events needing reminders", len(events))
+
+	for _, event := range events {
+		host, err := s.repos.Host.GetByID(ctx, event.HostID)
+		if err != nil || host == nil {
+			log.Printf("[REMINDER] Error fetching host %s for hosted event %s: %v", event.HostID, event.ID, err)
+			continue
+		}
+		tenant, err := s.repos.Tenant.GetByID(ctx, event.TenantID)
+		if err != nil || tenant == nil {
+			log.Printf("[REMINDER] Error fetching tenant %s for hosted event %s: %v", event.TenantID, event.ID, err)
+			continue
+		}
+		attendees, err := s.repos.HostedEventAttendee.ListByEvent(ctx, event.ID)
+		if err != nil {
+			log.Printf("[REMINDER] Error loading attendees for hosted event %s: %v", event.ID, err)
+			continue
+		}
+
+		for _, a := range attendees {
+			s.email.SendHostedEventReminder(ctx, event, a, host, tenant)
+		}
+
+		if err := s.repos.HostedEvent.MarkReminderSent(ctx, event.ID); err != nil {
+			log.Printf("[REMINDER] Error marking reminder sent for hosted event %s: %v", event.ID, err)
+		} else {
+			log.Printf("[REMINDER] Sent reminder for hosted event %s (%d attendees, at %s)",
+				event.ID, len(attendees), event.StartTime.Format(time.RFC3339))
 		}
 	}
 }

--- a/internal/services/reminder_test.go
+++ b/internal/services/reminder_test.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/config"
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+// TestReminder_processHostedEventReminders_FiresForEachAttendeeAndMarksSent
+// exercises the hosted-event branch of the reminder loop:
+//   - One scheduled hosted event sitting inside the 23-25h reminder window
+//   - Two attendees → expect two SendHostedEventReminder calls
+//   - reminder_sent flips to true after the dispatch
+//   - A second pass with the same window does not re-fire (because
+//     GetUpcomingForReminders filters reminder_sent rows)
+func TestReminder_processHostedEventReminders_FiresForEachAttendeeAndMarksSent(t *testing.T) {
+	_, repos, cleanup := setupTestRepos(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tenant := &models.Tenant{
+		ID: uuid.New().String(), Slug: "t", Name: "Tenant",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Tenant.Create(ctx, tenant); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	host := &models.Host{
+		ID: uuid.New().String(), TenantID: tenant.ID,
+		Email: "host@example.com", PasswordHash: "x", Name: "Host", Slug: "host",
+		Timezone: "UTC", CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Host.Create(ctx, host); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+
+	// Event scheduled in 24 hours, within the reminder window.
+	startAt := time.Now().UTC().Add(24 * time.Hour)
+	event := &models.HostedEvent{
+		ID: uuid.New().String(), TenantID: tenant.ID, HostID: host.ID,
+		Title: "Standup", StartTime: models.NewSQLiteTime(startAt),
+		EndTime: models.NewSQLiteTime(startAt.Add(30 * time.Minute)), Duration: 30,
+		Timezone: "UTC", LocationType: models.ConferencingProviderGoogleMeet,
+		Status:    models.HostedEventStatusScheduled,
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.HostedEvent.Create(ctx, event); err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	for _, email := range []string{"a@example.com", "b@example.com"} {
+		if err := repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, []*models.HostedEventAttendee{{
+			ID: uuid.New().String(), HostedEventID: event.ID, Email: email, Name: email,
+			CreatedAt: models.Now(),
+		}}); err != nil {
+			// ReplaceForEvent overwrites — switch to one call with both rows.
+			t.Fatalf("ReplaceForEvent: %v", err)
+		}
+	}
+	// Final attendee state: ReplaceForEvent above overwrites each call, so
+	// re-seed both atomically.
+	if err := repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, []*models.HostedEventAttendee{
+		{ID: uuid.New().String(), HostedEventID: event.ID, Email: "a@example.com", Name: "A", CreatedAt: models.Now()},
+		{ID: uuid.New().String(), HostedEventID: event.ID, Email: "b@example.com", Name: "B", CreatedAt: models.Now()},
+	}); err != nil {
+		t.Fatalf("seed final attendees: %v", err)
+	}
+
+	// We can't intercept the real EmailService send (it would try to dial
+	// SMTP), so swap in a config that points to a non-existent provider —
+	// reminder dispatch logs but still marks the event as sent. The thing we
+	// actually verify here is that GetUpcomingForReminders + MarkReminderSent
+	// drive the state machine correctly; email content is covered by the
+	// hosted_event_test.go spy.
+	cfg := &config.Config{}
+	cfg.Email.Provider = "smtp"
+	cfg.Email.SMTPHost = "127.0.0.1"
+	cfg.Email.SMTPPort = 1 // guaranteed-closed port
+	cfg.Email.FromAddress = "noreply@test.local"
+	emailSvc := NewEmailService(cfg)
+
+	reminder := NewReminderService(repos, emailSvc)
+	reminder.processHostedEventReminders(ctx, time.Now().UTC().Add(23*time.Hour), time.Now().UTC().Add(25*time.Hour))
+
+	post, err := repos.HostedEvent.GetByID(ctx, event.ID)
+	if err != nil || post == nil {
+		t.Fatalf("post-fetch event: %v / %v", err, post)
+	}
+	if !post.ReminderSent {
+		t.Fatal("expected reminder_sent=true after processHostedEventReminders")
+	}
+
+	// A second pass over the same window must not pick the event up again.
+	due, err := repos.HostedEvent.GetUpcomingForReminders(ctx, time.Now().UTC().Add(23*time.Hour), time.Now().UTC().Add(25*time.Hour))
+	if err != nil {
+		t.Fatalf("GetUpcomingForReminders second pass: %v", err)
+	}
+	for _, e := range due {
+		if e.ID == event.ID {
+			t.Fatal("event re-surfaced after reminder_sent was marked")
+		}
+	}
+}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -21,6 +21,7 @@ type Services struct {
 	Timezone     *TimezoneService
 	Agenda       *AgendaService
 	Contact      *ContactService
+	HostedEvent  *HostedEventService
 }
 
 // New creates all services
@@ -42,6 +43,7 @@ func New(cfg *config.Config, repos *repository.Repositories) *Services {
 
 	timezoneSvc := NewTimezoneService()
 	agendaSvc := NewAgendaService(repos, calendarSvc)
+	hostedEventSvc := NewHostedEventService(cfg, repos, calendarSvc, conferencingSvc, syncerSvc, emailSvc, contactSvc, auditLogSvc)
 
 	return &Services{
 		Auth:         authSvc,
@@ -58,5 +60,6 @@ func New(cfg *config.Config, repos *repository.Repositories) *Services {
 		Timezone:     timezoneSvc,
 		Agenda:       agendaSvc,
 		Contact:      contactSvc,
+		HostedEvent:  hostedEventSvc,
 	}
 }


### PR DESCRIPTION
## Summary

Phase C + F of the host-driven event scheduling work. Builds on the syncer + schema/repos already in #43 (this PR is targeted at #43's branch so the diff shows only the new work; once #43 merges to main, this PR will auto-rebase).

This PR is service + tests only — no handlers, no UI, no migrations. The next PR adds Phase D + E (routes/handlers + the dashboard UI via the \`frontend-design\` skill).

## What's new

### \`HostedEventService\` (\`internal/services/hosted_event.go\`)
Public surface: \`Create\`, \`Update\`, \`Cancel\`, \`Get\`, \`List\`, \`Archive\`, \`Unarchive\`, \`RetryCalendarEvent\`, \`DetectBusyConflicts\`.

Behavioural notes worth highlighting in review:
- **Calendar resolution priority**: explicit \`CalendarID\` input → template default → host \`DefaultCalendarID\` → first writable (the last fallback comes free from the syncer).
- **Two-write conferencing-link sequencing**: Zoom path persists the link first, then \`syncer.Create\` may surface a Google Meet link from the calendar create response, which is persisted with a second write.
- **\`ErrConferencingReauthRequired\` on \`Create\`** is logged and swallowed — the event still goes out without a link, matching booking-flow parity. On \`Update\` it surfaces.
- **\`reminder_sent\` is reset to \`false\` when \`Start\` changes** so the reminder loop re-fires for the new time.
- **Contact upsert fires only for newly added attendees**, so retained attendees don't get \`meeting_count\` / \`last_met\` re-incremented on benign edits.
- **\`DetectBusyConflicts\` merges three sources** — provider busy times, confirmed bookings, other hosted events — with \`excludeEventID\` for self-edit.
- The service depends on a narrow \`hostedEventEmailSender\` interface so tests can inject a spy without dialling SMTP. \`*EmailService\` satisfies it.

### Conferencing (\`internal/services/conferencing.go\`)
Extracted \`createZoomMeetingRaw(ctx, hostID, topic, start, durationMin)\` so both bookings and hosted events share the Zoom API call. New \`CreateMeetingForHostedEvent(...)\`. Existing \`CreateMeeting(details)\` keeps its public signature and now delegates internally.

### Contacts (\`internal/services/contact.go\`)
New \`UpsertFromHostedEventAttendee(ctx, tenantID, email, name, eventStart)\`.

### Email (\`internal/services/email.go\`)
Five new send methods following the inline-Go-string pattern of \`SendBookingConfirmed\` (\`email.go:184\`):
- \`SendHostedEventInvited\`
- \`SendHostedEventUpdated\` (with \`changedFields\`)
- \`SendHostedEventCancelled\` (METHOD:CANCEL ICS)
- \`SendHostedEventCancelledForAttendee\` (METHOD:CANCEL ICS, attendee-scoped)
- \`SendHostedEventReminder\`

Plus \`generateICSForHostedEvent(event, host, attendee, method, status)\`.

### Reminder (\`internal/services/reminder.go\`)
\`checkAndSendReminders\` now splits into \`processBookingReminders\` + \`processHostedEventReminders\` so a failure in one source can't abort the other.

## Tests

\`internal/services/hosted_event_test.go\` — 13 cases:
- \`PersistsEventAndAttendees\`
- \`ResolvesCalendarFromExplicit\`
- \`ResolvesCalendarFromTemplateThenHost\`
- \`ConferencingReauthRequired_StillPersistsEvent\`
- \`GoogleMeet_LinkFromSyncerPersisted\`
- \`SendsInvitedEmailToEachAttendee\`
- \`UpsertsContactsForAttendees\`
- \`Update_AttendeeDiff_RoutesEmailsCorrectly\` (added/removed/retained → invited/cancelled-for-attendee/updated)
- \`Update_TimeChange_ResetsReminderSent\`
- \`Update_NoMaterialChange_SendsNoEmail\`
- \`Update_PatchesAllTrackedCalendarEvents\`
- \`Update_ContactNotReupsertedForRetained\`
- \`Cancel_DeletesTrackedRowsAndEmails\`
- \`DetectBusyConflicts_ExcludesSelf\`

\`internal/services/reminder_test.go\` — \`processHostedEventReminders\` flips \`reminder_sent\` and prevents re-fire.

## Verification

- \`go build ./...\` clean
- \`go vet ./...\` clean
- \`go test ./...\` — all packages pass, including PR #43's syncer regression suite
- The pre-existing \`golangci-lint\` baseline reports 24 issues (errcheck + staticcheck) but none are in code touched by this PR; these issues exist on \`#43\`'s HEAD too and are out of scope here.

## Test plan

- [ ] Review the calendar-resolution priority + the two-write conferencing-link sequencing in \`Create\`
- [ ] Review the attendee-diff logic in \`Update\` (added/removed/retained, contact-upsert added-only, reminder_sent reset)
- [ ] Review the email content for tone + ICS METHOD/STATUS pairing
- [ ] Confirm the reminder loop split is the right approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)