### PR TITLE
feat(hosted-events): HostedEventService + email + reminder (Phase C + F)

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -376,6 +376,60 @@ type BookingCalendarEvent struct {
 	CreatedAt  SQLiteTime `json:"created_at" db:"created_at"`
 }
 
+// HostedEventStatus represents the status of a hosted event
+type HostedEventStatus string
+
+const (
+	HostedEventStatusScheduled HostedEventStatus = "scheduled"
+	HostedEventStatusCancelled HostedEventStatus = "cancelled"
+)
+
+// HostedEvent represents a host-driven scheduled meeting (the inverse of an
+// invitee-driven Booking). Hosts pick the time and attendees directly.
+type HostedEvent struct {
+	ID             string               `json:"id" db:"id"`
+	TenantID       string               `json:"tenant_id" db:"tenant_id"`
+	HostID         string               `json:"host_id" db:"host_id"`
+	TemplateID     *string              `json:"template_id" db:"template_id"`
+	Title          string               `json:"title" db:"title"`
+	Description    string               `json:"description" db:"description"`
+	StartTime      SQLiteTime           `json:"start_time" db:"start_time"`
+	EndTime        SQLiteTime           `json:"end_time" db:"end_time"`
+	Duration       int                  `json:"duration" db:"duration"`
+	Timezone       string               `json:"timezone" db:"timezone"`
+	LocationType   ConferencingProvider `json:"location_type" db:"location_type"`
+	CustomLocation string               `json:"custom_location" db:"custom_location"`
+	CalendarID     string               `json:"calendar_id" db:"calendar_id"`
+	ConferenceLink string               `json:"conference_link" db:"conference_link"`
+	Status         HostedEventStatus    `json:"status" db:"status"`
+	CancelReason   string               `json:"cancel_reason" db:"cancel_reason"`
+	ReminderSent   bool                 `json:"reminder_sent" db:"reminder_sent"`
+	IsArchived     bool                 `json:"is_archived" db:"is_archived"`
+	CreatedAt      SQLiteTime           `json:"created_at" db:"created_at"`
+	UpdatedAt      SQLiteTime           `json:"updated_at" db:"updated_at"`
+}
+
+// HostedEventAttendee is one attendee on a hosted event.
+type HostedEventAttendee struct {
+	ID            string     `json:"id" db:"id"`
+	HostedEventID string     `json:"hosted_event_id" db:"hosted_event_id"`
+	Email         string     `json:"email" db:"email"`
+	Name          string     `json:"name" db:"name"`
+	ContactID     *string    `json:"contact_id" db:"contact_id"`
+	CreatedAt     SQLiteTime `json:"created_at" db:"created_at"`
+}
+
+// HostedEventCalendarEvent tracks the per-host calendar events created for a
+// hosted event (parallel to BookingCalendarEvent for bookings).
+type HostedEventCalendarEvent struct {
+	ID            string     `json:"id" db:"id"`
+	HostedEventID string     `json:"hosted_event_id" db:"hosted_event_id"`
+	HostID        string     `json:"host_id" db:"host_id"`
+	CalendarID    string     `json:"calendar_id" db:"calendar_id"`
+	EventID       string     `json:"event_id" db:"event_id"`
+	CreatedAt     SQLiteTime `json:"created_at" db:"created_at"`
+}
+
 // Custom JSON types for PostgreSQL arrays and JSONB
 
 // IntSlice is a slice of integers that can be stored as JSONB

--- a/internal/repository/hosted_event.go
+++ b/internal/repository/hosted_event.go
@@ -1,0 +1,203 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+// HostedEventRepository handles hosted_events database operations.
+type HostedEventRepository struct {
+	db     *sql.DB
+	driver string
+}
+
+func (r *HostedEventRepository) Create(ctx context.Context, e *models.HostedEvent) error {
+	query := q(r.driver, `
+		INSERT INTO hosted_events (
+			id, tenant_id, host_id, template_id, title, description,
+			start_time, end_time, duration, timezone, location_type, custom_location,
+			calendar_id, conference_link, status, cancel_reason, reminder_sent, is_archived,
+			created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+	`)
+	_, err := r.db.ExecContext(ctx, query,
+		e.ID, e.TenantID, e.HostID, e.TemplateID, e.Title, e.Description,
+		e.StartTime, e.EndTime, e.Duration, e.Timezone, e.LocationType, e.CustomLocation,
+		e.CalendarID, e.ConferenceLink, e.Status, e.CancelReason, e.ReminderSent, e.IsArchived,
+		e.CreatedAt, e.UpdatedAt)
+	return err
+}
+
+const hostedEventSelect = `
+	SELECT id, tenant_id, host_id, template_id, title, description,
+	       start_time, end_time, duration, timezone, location_type, custom_location,
+	       calendar_id, conference_link, status, cancel_reason,
+	       COALESCE(reminder_sent, false), COALESCE(is_archived, false),
+	       created_at, updated_at
+	FROM hosted_events
+`
+
+func scanHostedEvent(row interface {
+	Scan(...interface{}) error
+}) (*models.HostedEvent, error) {
+	e := &models.HostedEvent{}
+	err := row.Scan(
+		&e.ID, &e.TenantID, &e.HostID, &e.TemplateID, &e.Title, &e.Description,
+		&e.StartTime, &e.EndTime, &e.Duration, &e.Timezone, &e.LocationType, &e.CustomLocation,
+		&e.CalendarID, &e.ConferenceLink, &e.Status, &e.CancelReason,
+		&e.ReminderSent, &e.IsArchived,
+		&e.CreatedAt, &e.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+func (r *HostedEventRepository) GetByID(ctx context.Context, id string) (*models.HostedEvent, error) {
+	query := q(r.driver, hostedEventSelect+` WHERE id = $1`)
+	e, err := scanHostedEvent(r.db.QueryRowContext(ctx, query, id))
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return e, err
+}
+
+func (r *HostedEventRepository) Update(ctx context.Context, e *models.HostedEvent) error {
+	query := q(r.driver, `
+		UPDATE hosted_events SET
+			title = $1, description = $2,
+			start_time = $3, end_time = $4, duration = $5, timezone = $6,
+			location_type = $7, custom_location = $8,
+			calendar_id = $9, conference_link = $10,
+			status = $11, cancel_reason = $12,
+			reminder_sent = $13, is_archived = $14,
+			updated_at = $15
+		WHERE id = $16
+	`)
+	_, err := r.db.ExecContext(ctx, query,
+		e.Title, e.Description,
+		e.StartTime, e.EndTime, e.Duration, e.Timezone,
+		e.LocationType, e.CustomLocation,
+		e.CalendarID, e.ConferenceLink,
+		e.Status, e.CancelReason,
+		e.ReminderSent, e.IsArchived,
+		e.UpdatedAt, e.ID)
+	return err
+}
+
+func (r *HostedEventRepository) ListByHost(ctx context.Context, hostID string, includeArchived bool) ([]*models.HostedEvent, error) {
+	query := hostedEventSelect + ` WHERE host_id = $1`
+	if !includeArchived {
+		query += ` AND (is_archived = false OR is_archived IS NULL)`
+	}
+	query += ` ORDER BY start_time DESC`
+	rows, err := r.db.QueryContext(ctx, q(r.driver, query), hostID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("Error closing rows: %v", err)
+		}
+	}()
+
+	var out []*models.HostedEvent
+	for rows.Next() {
+		e, err := scanHostedEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// GetByHostIDAndTimeRange returns non-cancelled hosted events for a host that
+// overlap the given window. excludeEventID, when non-nil, skips that event —
+// used by the conflict-detection endpoint when editing an existing event so
+// it doesn't report itself as a conflict.
+func (r *HostedEventRepository) GetByHostIDAndTimeRange(ctx context.Context, hostID string, start, end time.Time, excludeEventID *string) ([]*models.HostedEvent, error) {
+	// Placeholders must appear in strict $1,$2,...,$N order: q(driver, ...)
+	// replaces every "$N" with "?" for sqlite via plain regex substitution
+	// (see repository.go's q()), so the positional bind order falls out of
+	// the order placeholders appear in the query — not their numeric value.
+	query := hostedEventSelect + ` WHERE host_id = $1 AND status = 'scheduled' AND end_time > $2 AND start_time < $3`
+	// Format times to match the storage layout used by SQLiteTime.Value() so
+	// the TEXT comparison under sqlite is reliable. Postgres tolerates the
+	// same RFC-3339 string against TIMESTAMP columns.
+	args := []interface{}{hostID, formatTimeArg(start), formatTimeArg(end)}
+	if excludeEventID != nil {
+		query += ` AND id <> $4`
+		args = append(args, *excludeEventID)
+	}
+	query += ` ORDER BY start_time ASC`
+	rows, err := r.db.QueryContext(ctx, q(r.driver, query), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("Error closing rows: %v", err)
+		}
+	}()
+
+	var out []*models.HostedEvent
+	for rows.Next() {
+		e, err := scanHostedEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// GetUpcomingForReminders returns scheduled hosted events with start_time in
+// [start, end] that haven't had a reminder sent yet.
+func (r *HostedEventRepository) GetUpcomingForReminders(ctx context.Context, start, end time.Time) ([]*models.HostedEvent, error) {
+	query := q(r.driver, hostedEventSelect+`
+		WHERE status = 'scheduled'
+		  AND (reminder_sent = false OR reminder_sent IS NULL)
+		  AND start_time >= $1
+		  AND start_time <= $2
+		ORDER BY start_time ASC
+	`)
+	rows, err := r.db.QueryContext(ctx, query, formatTimeArg(start), formatTimeArg(end))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("Error closing rows: %v", err)
+		}
+	}()
+
+	var out []*models.HostedEvent
+	for rows.Next() {
+		e, err := scanHostedEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func (r *HostedEventRepository) MarkReminderSent(ctx context.Context, id string) error {
+	query := q(r.driver, `UPDATE hosted_events SET reminder_sent = true, updated_at = $1 WHERE id = $2`)
+	_, err := r.db.ExecContext(ctx, query, models.Now(), id)
+	return err
+}
+
+// formatTimeArg formats a time.Time into the RFC-3339 layout that
+// SQLiteTime.Value() emits, so the same string comparison works under sqlite's
+// TEXT columns regardless of how the driver would default-format raw
+// time.Time values.
+func formatTimeArg(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}

--- a/internal/repository/hosted_event_attendee.go
+++ b/internal/repository/hosted_event_attendee.go
@@ -1,0 +1,75 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"log"
+
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+// HostedEventAttendeeRepository handles hosted_event_attendees database
+// operations.
+type HostedEventAttendeeRepository struct {
+	db     *sql.DB
+	driver string
+}
+
+// ListByEvent returns all attendees for a hosted event, ordered by created_at.
+func (r *HostedEventAttendeeRepository) ListByEvent(ctx context.Context, eventID string) ([]*models.HostedEventAttendee, error) {
+	query := q(r.driver, `
+		SELECT id, hosted_event_id, email, COALESCE(name, ''), contact_id, created_at
+		FROM hosted_event_attendees
+		WHERE hosted_event_id = $1
+		ORDER BY created_at ASC
+	`)
+	rows, err := r.db.QueryContext(ctx, query, eventID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("Error closing rows: %v", err)
+		}
+	}()
+
+	var out []*models.HostedEventAttendee
+	for rows.Next() {
+		a := &models.HostedEventAttendee{}
+		if err := rows.Scan(&a.ID, &a.HostedEventID, &a.Email, &a.Name, &a.ContactID, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+// ReplaceForEvent atomically replaces the attendee list for an event:
+// deletes existing rows and inserts the new ones in a single transaction.
+// Simpler than diffing and matches the "host re-submits the form" UX.
+func (r *HostedEventAttendeeRepository) ReplaceForEvent(ctx context.Context, eventID string, attendees []*models.HostedEventAttendee) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	if _, err := tx.ExecContext(ctx, q(r.driver, `DELETE FROM hosted_event_attendees WHERE hosted_event_id = $1`), eventID); err != nil {
+		return err
+	}
+
+	insertQuery := q(r.driver, `
+		INSERT INTO hosted_event_attendees (id, hosted_event_id, email, name, contact_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`)
+	for _, a := range attendees {
+		a.HostedEventID = eventID
+		if _, err := tx.ExecContext(ctx, insertQuery,
+			a.ID, a.HostedEventID, a.Email, a.Name, a.ContactID, a.CreatedAt); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}

--- a/internal/repository/hosted_event_calendar_event.go
+++ b/internal/repository/hosted_event_calendar_event.go
@@ -1,0 +1,62 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+// HostedEventCalendarEventRepository tracks per-host calendar events for a
+// hosted event (parallel to BookingCalendarEventRepository).
+type HostedEventCalendarEventRepository struct {
+	db     *sql.DB
+	driver string
+}
+
+func (r *HostedEventCalendarEventRepository) Create(ctx context.Context, e *models.HostedEventCalendarEvent) error {
+	query := q(r.driver, `
+		INSERT INTO hosted_event_calendar_events (id, hosted_event_id, host_id, calendar_id, event_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`)
+	_, err := r.db.ExecContext(ctx, query,
+		e.ID, e.HostedEventID, e.HostID, e.CalendarID, e.EventID, e.CreatedAt)
+	return err
+}
+
+func (r *HostedEventCalendarEventRepository) GetByHostedEventID(ctx context.Context, eventID string) ([]*models.HostedEventCalendarEvent, error) {
+	query := q(r.driver, `
+		SELECT id, hosted_event_id, host_id, calendar_id, event_id, created_at
+		FROM hosted_event_calendar_events
+		WHERE hosted_event_id = $1
+	`)
+	rows, err := r.db.QueryContext(ctx, query, eventID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []*models.HostedEventCalendarEvent
+	for rows.Next() {
+		e := &models.HostedEventCalendarEvent{}
+		if err := rows.Scan(&e.ID, &e.HostedEventID, &e.HostID, &e.CalendarID, &e.EventID, &e.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func (r *HostedEventCalendarEventRepository) DeleteByHostedEventID(ctx context.Context, eventID string) error {
+	query := q(r.driver, `DELETE FROM hosted_event_calendar_events WHERE hosted_event_id = $1`)
+	_, err := r.db.ExecContext(ctx, query, eventID)
+	return err
+}
+
+// Update changes the event_id (and optionally calendar_id) of a tracking row.
+// Used after a CalDAV-style replace or a fall-back create on update.
+func (r *HostedEventCalendarEventRepository) Update(ctx context.Context, e *models.HostedEventCalendarEvent) error {
+	query := q(r.driver, `UPDATE hosted_event_calendar_events SET event_id = $1, calendar_id = $2 WHERE id = $3`)
+	_, err := r.db.ExecContext(ctx, query, e.EventID, e.CalendarID, e.ID)
+	return err
+}

--- a/internal/repository/hosted_event_test.go
+++ b/internal/repository/hosted_event_test.go
@@ -1,0 +1,198 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+func TestHostedEventRepository_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+	}{
+		{"PostgreSQL", "postgres"},
+		{"SQLite", "sqlite"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.driver == "postgres" && !isPostgresAvailable() {
+				t.Skip("PostgreSQL not available")
+			}
+
+			db, cleanup := setupTestDB(t, tt.driver)
+			defer cleanup()
+			repos := NewRepositories(db, tt.driver)
+			ctx := context.Background()
+
+			tenantID, hostID := seedHostedEventParents(t, repos)
+
+			start := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+			end := start.Add(30 * time.Minute)
+			templateID := "" // nullable; pass nil
+			event := &models.HostedEvent{
+				ID:           uuid.New().String(),
+				TenantID:     tenantID,
+				HostID:       hostID,
+				TemplateID:   nullableID(templateID),
+				Title:        "Coffee chat",
+				Description:  "intro",
+				StartTime:    models.NewSQLiteTime(start),
+				EndTime:      models.NewSQLiteTime(end),
+				Duration:     30,
+				Timezone:     "UTC",
+				LocationType: models.ConferencingProviderGoogleMeet,
+				Status:       models.HostedEventStatusScheduled,
+				CreatedAt:    models.Now(),
+				UpdatedAt:    models.Now(),
+			}
+			if err := repos.HostedEvent.Create(ctx, event); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			got, err := repos.HostedEvent.GetByID(ctx, event.ID)
+			if err != nil {
+				t.Fatalf("GetByID: %v", err)
+			}
+			if got == nil || got.Title != "Coffee chat" {
+				t.Fatalf("unexpected event: %+v", got)
+			}
+
+			// ListByHost should return it.
+			list, err := repos.HostedEvent.ListByHost(ctx, hostID, false)
+			if err != nil {
+				t.Fatalf("ListByHost: %v", err)
+			}
+			if len(list) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(list))
+			}
+
+			// GetByHostIDAndTimeRange should overlap.
+			overlapping, err := repos.HostedEvent.GetByHostIDAndTimeRange(ctx, hostID, start.Add(-time.Hour), end.Add(time.Hour), nil)
+			if err != nil {
+				t.Fatalf("GetByHostIDAndTimeRange: %v", err)
+			}
+			if len(overlapping) != 1 {
+				t.Fatalf("expected 1 overlapping, got %d", len(overlapping))
+			}
+
+			// excludeEventID filter.
+			selfExcluded, err := repos.HostedEvent.GetByHostIDAndTimeRange(ctx, hostID, start.Add(-time.Hour), end.Add(time.Hour), &event.ID)
+			if err != nil {
+				t.Fatalf("GetByHostIDAndTimeRange (exclude): %v", err)
+			}
+			if len(selfExcluded) != 0 {
+				t.Fatalf("expected 0 when excluding self, got %d", len(selfExcluded))
+			}
+
+			// MarkReminderSent.
+			if err := repos.HostedEvent.MarkReminderSent(ctx, event.ID); err != nil {
+				t.Fatalf("MarkReminderSent: %v", err)
+			}
+			fresh, _ := repos.HostedEvent.GetByID(ctx, event.ID)
+			if !fresh.ReminderSent {
+				t.Fatal("ReminderSent not persisted")
+			}
+		})
+	}
+}
+
+func TestHostedEventAttendeeRepository_ReplaceForEvent(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+	}{
+		{"PostgreSQL", "postgres"},
+		{"SQLite", "sqlite"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.driver == "postgres" && !isPostgresAvailable() {
+				t.Skip("PostgreSQL not available")
+			}
+			db, cleanup := setupTestDB(t, tt.driver)
+			defer cleanup()
+			repos := NewRepositories(db, tt.driver)
+			ctx := context.Background()
+
+			tenantID, hostID := seedHostedEventParents(t, repos)
+			event := &models.HostedEvent{
+				ID: uuid.New().String(), TenantID: tenantID, HostID: hostID,
+				Title: "x", Duration: 30, Timezone: "UTC",
+				StartTime: models.Now(), EndTime: models.Now(),
+				LocationType: models.ConferencingProviderGoogleMeet,
+				Status:       models.HostedEventStatusScheduled,
+				CreatedAt:    models.Now(), UpdatedAt: models.Now(),
+			}
+			if err := repos.HostedEvent.Create(ctx, event); err != nil {
+				t.Fatalf("event create: %v", err)
+			}
+
+			first := []*models.HostedEventAttendee{
+				{ID: uuid.New().String(), Email: "a@example.com", Name: "A", CreatedAt: models.Now()},
+				{ID: uuid.New().String(), Email: "b@example.com", Name: "B", CreatedAt: models.Now()},
+			}
+			if err := repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, first); err != nil {
+				t.Fatalf("Replace 1: %v", err)
+			}
+
+			got, err := repos.HostedEventAttendee.ListByEvent(ctx, event.ID)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if len(got) != 2 {
+				t.Fatalf("expected 2 attendees, got %d", len(got))
+			}
+
+			// Replace with a different set; previous rows must be gone.
+			second := []*models.HostedEventAttendee{
+				{ID: uuid.New().String(), Email: "c@example.com", Name: "C", CreatedAt: models.Now()},
+			}
+			if err := repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, second); err != nil {
+				t.Fatalf("Replace 2: %v", err)
+			}
+			got2, _ := repos.HostedEventAttendee.ListByEvent(ctx, event.ID)
+			if len(got2) != 1 || got2[0].Email != "c@example.com" {
+				t.Fatalf("unexpected after replace 2: %+v", got2)
+			}
+		})
+	}
+}
+
+func nullableID(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// seedHostedEventParents inserts the minimum tenant + host needed to satisfy
+// hosted_events foreign keys. Returns the IDs.
+func seedHostedEventParents(t *testing.T, repos *Repositories) (tenantID, hostID string) {
+	t.Helper()
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+
+	tenant := &models.Tenant{
+		ID: uuid.New().String(), Slug: "t-" + suffix, Name: "Tenant",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Tenant.Create(ctx, tenant); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	host := &models.Host{
+		ID: uuid.New().String(), TenantID: tenant.ID,
+		Email: "h-" + suffix + "@example.com", PasswordHash: "x",
+		Name: "Host", Slug: "host-" + suffix, Timezone: "UTC",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Host.Create(ctx, host); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+	return tenant.ID, host.ID
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -13,39 +13,45 @@ import (
 
 // Repositories holds all repository instances
 type Repositories struct {
-	Tenant               *TenantRepository
-	Host                 *HostRepository
-	Calendar             *CalendarRepository
-	ProviderCalendar     *ProviderCalendarRepository
-	Conferencing         *ConferencingRepository
-	Template             *TemplateRepository
-	Booking              *BookingRepository
-	Session              *SessionRepository
-	WorkingHours         *WorkingHoursRepository
-	AuditLog             *AuditLogRepository
-	SignupConversion     *SignupConversionRepository
-	TemplateHost         *TemplateHostRepository
-	BookingCalendarEvent *BookingCalendarEventRepository
-	Contact              *ContactRepository
+	Tenant                   *TenantRepository
+	Host                     *HostRepository
+	Calendar                 *CalendarRepository
+	ProviderCalendar         *ProviderCalendarRepository
+	Conferencing             *ConferencingRepository
+	Template                 *TemplateRepository
+	Booking                  *BookingRepository
+	Session                  *SessionRepository
+	WorkingHours             *WorkingHoursRepository
+	AuditLog                 *AuditLogRepository
+	SignupConversion         *SignupConversionRepository
+	TemplateHost             *TemplateHostRepository
+	BookingCalendarEvent     *BookingCalendarEventRepository
+	Contact                  *ContactRepository
+	HostedEvent              *HostedEventRepository
+	HostedEventAttendee      *HostedEventAttendeeRepository
+	HostedEventCalendarEvent *HostedEventCalendarEventRepository
 }
 
 // NewRepositories creates all repositories
 func NewRepositories(db *sql.DB, driver string) *Repositories {
 	return &Repositories{
-		Tenant:               &TenantRepository{db: db, driver: driver},
-		Host:                 &HostRepository{db: db, driver: driver},
-		Calendar:             &CalendarRepository{db: db, driver: driver},
-		ProviderCalendar:     &ProviderCalendarRepository{db: db, driver: driver},
-		Conferencing:         &ConferencingRepository{db: db, driver: driver},
-		Template:             &TemplateRepository{db: db, driver: driver},
-		Booking:              &BookingRepository{db: db, driver: driver},
-		Session:              &SessionRepository{db: db, driver: driver},
-		WorkingHours:         &WorkingHoursRepository{db: db, driver: driver},
-		AuditLog:             &AuditLogRepository{db: db, driver: driver},
-		SignupConversion:     &SignupConversionRepository{db: db, driver: driver},
-		TemplateHost:         &TemplateHostRepository{db: db, driver: driver},
-		BookingCalendarEvent: &BookingCalendarEventRepository{db: db, driver: driver},
-		Contact:              &ContactRepository{db: db, driver: driver},
+		Tenant:                   &TenantRepository{db: db, driver: driver},
+		Host:                     &HostRepository{db: db, driver: driver},
+		Calendar:                 &CalendarRepository{db: db, driver: driver},
+		ProviderCalendar:         &ProviderCalendarRepository{db: db, driver: driver},
+		Conferencing:             &ConferencingRepository{db: db, driver: driver},
+		Template:                 &TemplateRepository{db: db, driver: driver},
+		Booking:                  &BookingRepository{db: db, driver: driver},
+		Session:                  &SessionRepository{db: db, driver: driver},
+		WorkingHours:             &WorkingHoursRepository{db: db, driver: driver},
+		AuditLog:                 &AuditLogRepository{db: db, driver: driver},
+		SignupConversion:         &SignupConversionRepository{db: db, driver: driver},
+		TemplateHost:             &TemplateHostRepository{db: db, driver: driver},
+		BookingCalendarEvent:     &BookingCalendarEventRepository{db: db, driver: driver},
+		Contact:                  &ContactRepository{db: db, driver: driver},
+		HostedEvent:              &HostedEventRepository{db: db, driver: driver},
+		HostedEventAttendee:      &HostedEventAttendeeRepository{db: db, driver: driver},
+		HostedEventCalendarEvent: &HostedEventCalendarEventRepository{db: db, driver: driver},
 	}
 }
 

--- a/internal/services/booking.go
+++ b/internal/services/booking.go
@@ -41,6 +41,7 @@ type BookingService struct {
 	cfg          *config.Config
 	repos        *repository.Repositories
 	calendar     *CalendarService
+	syncer       *CalendarEventSyncer
 	conferencing *ConferencingService
 	email        *EmailService
 	auditLog     *AuditLogService
@@ -52,6 +53,7 @@ func NewBookingService(
 	cfg *config.Config,
 	repos *repository.Repositories,
 	calendar *CalendarService,
+	syncer *CalendarEventSyncer,
 	conferencing *ConferencingService,
 	email *EmailService,
 	auditLog *AuditLogService,
@@ -61,6 +63,7 @@ func NewBookingService(
 		cfg:          cfg,
 		repos:        repos,
 		calendar:     calendar,
+		syncer:       syncer,
 		conferencing: conferencing,
 		email:        email,
 		auditLog:     auditLog,
@@ -319,35 +322,27 @@ func (s *BookingService) CancelBooking(ctx context.Context, bookingID, cancelled
 	return nil
 }
 
-// deleteAllCalendarEvents deletes calendar events for all hosts (pooled and legacy single-host)
+// deleteAllCalendarEvents deletes calendar events for all hosts. Tracked rows
+// (pooled and post-refactor single-host) flow through the syncer; pre-refactor
+// bookings that only have booking.CalendarEventID + template.CalendarID still
+// fall back to a direct DeleteEvent call.
 func (s *BookingService) deleteAllCalendarEvents(ctx context.Context, booking *models.Booking) {
-	// First, try to delete events from booking_calendar_events table (pooled hosts)
-	calEvents, err := s.repos.BookingCalendarEvent.GetByBookingID(ctx, booking.ID)
+	deleted, err := s.syncer.Delete(ctx, ItemKindBooking, booking.ID)
 	if err != nil {
-		log.Printf("[BOOKING] Error loading calendar events for booking %s: %v", booking.ID, err)
+		log.Printf("[BOOKING] Error during syncer delete for booking %s: %v", booking.ID, err)
 	}
-
-	if len(calEvents) > 0 {
-		// Delete events for all pooled hosts
-		for _, ce := range calEvents {
-			if err := s.calendar.DeleteEvent(ctx, ce.HostID, ce.CalendarID, ce.EventID); err != nil {
-				log.Printf("[BOOKING] Error deleting calendar event %s for host %s: %v", ce.EventID, ce.HostID, err)
-			} else {
-				log.Printf("[BOOKING] Deleted calendar event %s for host %s", ce.EventID, ce.HostID)
-			}
-		}
-		// Clean up the booking_calendar_events records
-		if err := s.repos.BookingCalendarEvent.DeleteByBookingID(ctx, booking.ID); err != nil {
-			log.Printf("[BOOKING] Error deleting booking_calendar_events records: %v", err)
-		}
-	} else if booking.CalendarEventID != "" {
-		// Fall back to legacy single-host event deletion
-		template, _ := s.repos.Template.GetByID(ctx, booking.TemplateID)
-		if template != nil {
-			if err := s.calendar.DeleteEvent(ctx, booking.HostID, template.CalendarID, booking.CalendarEventID); err != nil {
-				log.Printf("[BOOKING] Error deleting legacy calendar event: %v", err)
-			}
-		}
+	if deleted > 0 {
+		return
+	}
+	if booking.CalendarEventID == "" {
+		return
+	}
+	template, _ := s.repos.Template.GetByID(ctx, booking.TemplateID)
+	if template == nil {
+		return
+	}
+	if err := s.calendar.DeleteEvent(ctx, booking.HostID, template.CalendarID, booking.CalendarEventID); err != nil {
+		log.Printf("[BOOKING] Error deleting legacy calendar event: %v", err)
 	}
 }
 
@@ -476,53 +471,38 @@ func (s *BookingService) UpdateBooking(ctx context.Context, input UpdateBookingI
 }
 
 // updateAllCalendarEvents patches the calendar event(s) for a booking after a
-// host edit. Mirrors deleteAllCalendarEvents: pooled-host events live in
-// booking_calendar_events; legacy single-host bookings have only
-// booking.CalendarEventID with template.CalendarID as the calendar.
+// host edit. Tracked rows flow through the syncer (which preserves the
+// per-host ID and writes back any replacement ID returned by the provider).
+// For pre-refactor bookings that only have booking.CalendarEventID +
+// template.CalendarID, falls back to a direct UpdateEvent call.
 func (s *BookingService) updateAllCalendarEvents(ctx context.Context, details *BookingWithDetails, template *models.MeetingTemplate) {
-	calEvents, err := s.repos.BookingCalendarEvent.GetByBookingID(ctx, details.Booking.ID)
+	rows, err := s.repos.BookingCalendarEvent.GetByBookingID(ctx, details.Booking.ID)
 	if err != nil {
 		log.Printf("[BOOKING] Error loading calendar events for booking %s: %v", details.Booking.ID, err)
 	}
 
-	if len(calEvents) > 0 {
-		for _, ce := range calEvents {
-			perHost := &BookingWithDetails{
-				Booking:  details.Booking,
-				Template: template,
-				Host:     details.Host,
-				Tenant:   details.Tenant,
-			}
-			// Force the per-host event ID through CalendarEventID so the
-			// PATCH targets the correct event for this calendar.
-			savedID := perHost.Booking.CalendarEventID
-			perHost.Booking.CalendarEventID = ce.EventID
-			newID, err := s.calendar.UpdateEvent(ctx, perHost, ce.CalendarID)
-			perHost.Booking.CalendarEventID = savedID
-			if err != nil {
-				log.Printf("[BOOKING] Error updating calendar event %s for host %s: %v", ce.EventID, ce.HostID, err)
-				continue
-			}
-			if newID != "" && newID != ce.EventID {
-				// CalDAV path replaced the event; persist the new ID.
-				ce.EventID = newID
-				if err := s.repos.BookingCalendarEvent.Update(ctx, ce); err != nil {
-					log.Printf("[BOOKING] Error updating booking_calendar_events record: %v", err)
-				}
-			}
+	if len(rows) > 0 {
+		input := s.calendar.BuildCalendarEventInputForBooking(details)
+		req := CalendarSyncRequest{
+			Kind:   ItemKindBooking,
+			ItemID: details.Booking.ID,
+			Input:  *input,
+		}
+		if err := s.syncer.Update(ctx, req); err != nil {
+			log.Printf("[BOOKING] Error during syncer update for booking %s: %v", details.Booking.ID, err)
 		}
 		return
 	}
 
 	if details.Booking.CalendarEventID != "" && template.CalendarID != "" {
-		newID, err := s.calendar.UpdateEvent(ctx, details, template.CalendarID)
+		input := s.calendar.BuildCalendarEventInputForBooking(details)
+		newID, err := s.calendar.UpdateEvent(ctx, template.CalendarID, input)
 		if err != nil {
 			log.Printf("[BOOKING] Error updating legacy calendar event: %v", err)
 			return
 		}
 		if newID != "" && newID != details.Booking.CalendarEventID {
 			details.Booking.CalendarEventID = newID
-			// Persist the swapped ID so reschedule/cancel still find the event.
 			if err := s.repos.Booking.Update(ctx, details.Booking); err != nil {
 				log.Printf("[BOOKING] Error persisting new event ID: %v", err)
 			}
@@ -704,23 +684,22 @@ func (s *BookingService) RescheduleBooking(ctx context.Context, input Reschedule
 			}
 		}
 
-		// Load pooled hosts and create calendar events for all of them
-		pooledHosts, err := s.repos.TemplateHost.GetByTemplateIDWithHost(ctx, template.ID)
+		hosts := s.bookingHostTargets(ctx, details)
+		input := s.calendar.BuildCalendarEventInputForBooking(details)
+		firstID, conferenceLink, err := s.syncer.Create(ctx, CalendarSyncRequest{
+			Kind:   ItemKindBooking,
+			ItemID: details.Booking.ID,
+			Input:  *input,
+			Hosts:  hosts,
+		})
 		if err != nil {
-			log.Printf("[RESCHEDULE] Error loading pooled hosts: %v", err)
-			pooledHosts = nil
+			log.Printf("[RESCHEDULE] Error during syncer create: %v", err)
 		}
-
-		if len(pooledHosts) > 0 {
-			s.createPooledHostCalendarEvents(ctx, details, pooledHosts)
-		} else {
-			// Single-host flow (backward compatibility)
-			eventID, err := s.calendar.CreateEvent(ctx, details)
-			if err != nil {
-				log.Printf("[RESCHEDULE] Error creating calendar event: %v", err)
-			} else if eventID != "" {
-				details.Booking.CalendarEventID = eventID
-			}
+		if firstID != "" {
+			details.Booking.CalendarEventID = firstID
+		}
+		if conferenceLink != "" && details.Booking.ConferenceLink == "" {
+			details.Booking.ConferenceLink = conferenceLink
 		}
 
 		// Update booking with new conference link and event ID
@@ -871,22 +850,22 @@ func (s *BookingService) RetryCalendarEvent(ctx context.Context, hostID, tenantI
 		Tenant:   tenant,
 	}
 
-	// Load pooled hosts for this template
-	pooledHosts, err := s.repos.TemplateHost.GetByTemplateIDWithHost(ctx, template.ID)
+	hosts := s.bookingHostTargets(ctx, details)
+	input := s.calendar.BuildCalendarEventInputForBooking(details)
+	firstID, conferenceLink, err := s.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: details.Booking.ID,
+		Input:  *input,
+		Hosts:  hosts,
+	})
 	if err != nil {
-		pooledHosts = nil
+		return fmt.Errorf("failed to create calendar event: %w", err)
 	}
-
-	if len(pooledHosts) > 0 {
-		s.createPooledHostCalendarEvents(ctx, details, pooledHosts)
-	} else {
-		eventID, err := s.calendar.CreateEvent(ctx, details)
-		if err != nil {
-			return fmt.Errorf("failed to create calendar event: %w", err)
-		}
-		if eventID != "" {
-			details.Booking.CalendarEventID = eventID
-		}
+	if firstID != "" {
+		details.Booking.CalendarEventID = firstID
+	}
+	if conferenceLink != "" && details.Booking.ConferenceLink == "" {
+		details.Booking.ConferenceLink = conferenceLink
 	}
 
 	// Update booking with the new event ID
@@ -960,29 +939,22 @@ func (s *BookingService) processConfirmedBooking(ctx context.Context, details *B
 		}
 	}
 
-	// Load pooled hosts for this template
-	pooledHosts, err := s.repos.TemplateHost.GetByTemplateIDWithHost(ctx, details.Template.ID)
+	hosts := s.bookingHostTargets(ctx, details)
+	input := s.calendar.BuildCalendarEventInputForBooking(details)
+	firstID, conferenceLink, err := s.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: details.Booking.ID,
+		Input:  *input,
+		Hosts:  hosts,
+	})
 	if err != nil {
-		log.Printf("[BOOKING] Error loading pooled hosts: %v", err)
-		// Continue with single-host flow
-		pooledHosts = nil
+		log.Printf("[BOOKING] Error during syncer create for booking %s: %v", details.Booking.ID, err)
 	}
-
-	// Create calendar events for all pooled hosts (or just owner if no pooled hosts)
-	if len(pooledHosts) > 0 {
-		s.createPooledHostCalendarEvents(ctx, details, pooledHosts)
-	} else {
-		// Single-host flow (backward compatibility)
-		log.Printf("[BOOKING] Creating calendar event for single host...")
-		eventID, err := s.calendar.CreateEvent(ctx, details)
-		if err != nil {
-			log.Printf("[BOOKING] Error creating calendar event: %v", err)
-		} else if eventID != "" {
-			log.Printf("[BOOKING] Calendar event created: %s", eventID)
-			details.Booking.CalendarEventID = eventID
-		} else {
-			log.Printf("[BOOKING] No calendar event created (no calendar configured or empty response)")
-		}
+	if firstID != "" && details.Booking.CalendarEventID == "" {
+		details.Booking.CalendarEventID = firstID
+	}
+	if conferenceLink != "" && details.Booking.ConferenceLink == "" {
+		details.Booking.ConferenceLink = conferenceLink
 	}
 
 	// Update booking with conference link and event ID
@@ -1000,81 +972,35 @@ func (s *BookingService) processConfirmedBooking(ctx context.Context, details *B
 	return nil
 }
 
-// createPooledHostCalendarEvents creates calendar events for all hosts in a pooled template
-func (s *BookingService) createPooledHostCalendarEvents(ctx context.Context, details *BookingWithDetails, pooledHosts []*models.TemplateHost) {
-	for _, th := range pooledHosts {
-		// Get the host's default calendar
-		host := th.Host
-		if host == nil {
-			var err error
-			host, err = s.repos.Host.GetByID(ctx, th.HostID)
-			if err != nil || host == nil {
-				log.Printf("[BOOKING] Error loading host %s: %v", th.HostID, err)
-				continue
-			}
-		}
-
-		// Find the host's default provider calendar (writable). Falls back to
-		// any writable provider calendar if none is configured.
-		var calendarID string
-		if host.DefaultCalendarID != nil {
-			calendarID = *host.DefaultCalendarID
-		}
-		if calendarID == "" {
-			pcs, err := s.repos.ProviderCalendar.GetByHostID(ctx, th.HostID)
-			if err != nil {
-				log.Printf("[BOOKING] No calendar found for host %s, skipping event creation", th.HostID)
-				continue
-			}
-			for _, pc := range pcs {
-				if pc.IsWritable {
-					calendarID = pc.ID
-					break
-				}
-			}
-			if calendarID == "" {
-				log.Printf("[BOOKING] No writable calendar for host %s, skipping event creation", th.HostID)
-				continue
-			}
-		}
-
-		// Create a modified details with this host's info for event creation
-		hostDetails := &BookingWithDetails{
-			Booking:  details.Booking,
-			Template: details.Template,
-			Host:     host,
-			Tenant:   details.Tenant,
-		}
-
-		// Create calendar event for this host
-		eventID, err := s.calendar.CreateEventForHost(ctx, hostDetails, calendarID)
-		if err != nil {
-			log.Printf("[BOOKING] Error creating calendar event for host %s: %v", th.HostID, err)
-			continue
-		}
-
-		if eventID != "" {
-			log.Printf("[BOOKING] Calendar event created for host %s: %s", th.HostID, eventID)
-
-			// Store in booking_calendar_events table
-			calEvent := &models.BookingCalendarEvent{
-				ID:         uuid.New().String(),
-				BookingID:  details.Booking.ID,
-				HostID:     th.HostID,
-				CalendarID: calendarID,
-				EventID:    eventID,
-				CreatedAt:  models.Now(),
-			}
-			if err := s.repos.BookingCalendarEvent.Create(ctx, calEvent); err != nil {
-				log.Printf("[BOOKING] Error storing calendar event record: %v", err)
-			}
-
-			// Store first event ID in booking for backward compatibility
-			if details.Booking.CalendarEventID == "" && th.Role == models.TemplateHostRoleOwner {
-				details.Booking.CalendarEventID = eventID
-			}
-		}
+// bookingHostTargets resolves the calendar fan-out targets for a booking:
+// pooled hosts when the template has any (owner first, siblings after), or
+// just the booking host when the template is single-host. Each target's
+// CalendarID is left empty when the syncer should resolve it from the host's
+// default + first writable fallback.
+func (s *BookingService) bookingHostTargets(ctx context.Context, details *BookingWithDetails) []HostTarget {
+	pooled, err := s.repos.TemplateHost.GetByTemplateIDWithHost(ctx, details.Template.ID)
+	if err != nil {
+		log.Printf("[BOOKING] Error loading pooled hosts: %v", err)
+		pooled = nil
 	}
+	if len(pooled) == 0 {
+		// Single-host fallback: write to the template's configured calendar.
+		return []HostTarget{{
+			HostID:     details.Booking.HostID,
+			CalendarID: details.Template.CalendarID,
+			IsOwner:    true,
+		}}
+	}
+	targets := make([]HostTarget, 0, len(pooled))
+	for _, th := range pooled {
+		targets = append(targets, HostTarget{
+			HostID:  th.HostID,
+			IsOwner: th.Role == models.TemplateHostRoleOwner,
+			// CalendarID intentionally empty — syncer resolves the host's
+			// default writable calendar.
+		})
+	}
+	return targets
 }
 
 // recordConferencingFailure marks a booking with a conferencing-link failure so

--- a/internal/services/booking_calendar_sync_test.go
+++ b/internal/services/booking_calendar_sync_test.go
@@ -1,0 +1,496 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/models"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// fakeCalendarWriter records calls and returns programmed responses. Lets
+// syncer tests run without hitting the network and lets us assert exact
+// per-host fan-out behaviour.
+type fakeCalendarWriter struct {
+	createCalls []fakeCreateCall
+	updateCalls []fakeUpdateCall
+	deleteCalls []fakeDeleteCall
+
+	// nextCreate is consulted in order; missing entries default to a generated
+	// success.
+	nextCreate []fakeCreateResult
+	// nextUpdate likewise.
+	nextUpdate []fakeUpdateResult
+
+	// createErrForCalendarID: any create call whose target calendar matches
+	// returns the configured error.
+	createErrForCalendarID map[string]error
+	updateErrForCalendarID map[string]error
+}
+
+type fakeCreateCall struct {
+	CalendarID string
+	Input      CalendarEventInput
+}
+
+type fakeUpdateCall struct {
+	CalendarID string
+	Input      CalendarEventInput
+}
+
+type fakeDeleteCall struct {
+	HostID, CalendarID, EventID string
+}
+
+type fakeCreateResult struct {
+	EventID        string
+	ConferenceLink string
+	Err            error
+}
+
+type fakeUpdateResult struct {
+	EventID string
+	Err     error
+}
+
+func (f *fakeCalendarWriter) CreateEventForHost(_ context.Context, providerCalendarID string, input *CalendarEventInput) (string, string, error) {
+	f.createCalls = append(f.createCalls, fakeCreateCall{CalendarID: providerCalendarID, Input: *input})
+	if err, ok := f.createErrForCalendarID[providerCalendarID]; ok {
+		return "", "", err
+	}
+	if len(f.nextCreate) > 0 {
+		r := f.nextCreate[0]
+		f.nextCreate = f.nextCreate[1:]
+		return r.EventID, r.ConferenceLink, r.Err
+	}
+	return "evt-" + providerCalendarID + "-" + uuid.New().String()[:8], "", nil
+}
+
+func (f *fakeCalendarWriter) UpdateEvent(_ context.Context, providerCalendarID string, input *CalendarEventInput) (string, error) {
+	f.updateCalls = append(f.updateCalls, fakeUpdateCall{CalendarID: providerCalendarID, Input: *input})
+	if err, ok := f.updateErrForCalendarID[providerCalendarID]; ok {
+		return "", err
+	}
+	if len(f.nextUpdate) > 0 {
+		r := f.nextUpdate[0]
+		f.nextUpdate = f.nextUpdate[1:]
+		return r.EventID, r.Err
+	}
+	return input.EventID, nil
+}
+
+func (f *fakeCalendarWriter) DeleteEvent(_ context.Context, hostID, providerCalendarID, eventID string) error {
+	f.deleteCalls = append(f.deleteCalls, fakeDeleteCall{HostID: hostID, CalendarID: providerCalendarID, EventID: eventID})
+	return nil
+}
+
+// fixture holds the minimum row set needed to satisfy booking_calendar_events
+// foreign keys.
+type fixture struct {
+	tenantID   string
+	templateID string
+	bookingID  string
+	hostIDs    []string
+	calendars  map[string]string // hostID → provider_calendar.id
+}
+
+// syncerHarness bundles a syncer wired to real repositories with the fake
+// calendar writer and a seeded fixture.
+type syncerHarness struct {
+	syncer  *CalendarEventSyncer
+	fake    *fakeCalendarWriter
+	fixture *fixture
+	cleanup func()
+}
+
+func makeSyncerHarness(t *testing.T, hostCount int) *syncerHarness {
+	t.Helper()
+	db, repos, cleanup := setupTestRepos(t)
+	fix := seedFixture(t, db, repos, hostCount)
+	fake := &fakeCalendarWriter{}
+	s := &CalendarEventSyncer{
+		repos:    repos,
+		calendar: fake,
+		stores: map[ScheduledItemKind]trackingStore{
+			ItemKindBooking: &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+		},
+	}
+	return &syncerHarness{syncer: s, fake: fake, fixture: fix, cleanup: cleanup}
+}
+
+func seedFixture(t *testing.T, db *sql.DB, repos *repositoryWrapper, hostCount int) *fixture {
+	t.Helper()
+	ctx := context.Background()
+	short := func(s string) string { return s[:8] }
+
+	tenant := &models.Tenant{
+		ID: uuid.New().String(), Slug: "t-" + uuid.New().String()[:6], Name: "Test Tenant",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Tenant.Create(ctx, tenant); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+
+	hosts := make([]string, 0, hostCount)
+	cals := map[string]string{}
+	for i := 0; i < hostCount; i++ {
+		host := &models.Host{
+			ID:           uuid.New().String(),
+			TenantID:     tenant.ID,
+			Email:        "h" + uuid.New().String()[:4] + "@example.com",
+			PasswordHash: "x",
+			Name:         "Host",
+			Slug:         "host-" + uuid.New().String()[:6],
+			Timezone:     "UTC",
+			CreatedAt:    models.Now(),
+			UpdatedAt:    models.Now(),
+		}
+		if err := repos.Host.Create(ctx, host); err != nil {
+			t.Fatalf("create host: %v", err)
+		}
+		hosts = append(hosts, host.ID)
+
+		conn := &models.CalendarConnection{
+			ID: uuid.New().String(), HostID: host.ID,
+			Provider: models.CalendarProviderGoogle, Name: "gmail",
+			CreatedAt: models.Now(), UpdatedAt: models.Now(),
+		}
+		if err := repos.Calendar.Create(ctx, conn); err != nil {
+			t.Fatalf("create calendar conn: %v", err)
+		}
+
+		pc := &models.ProviderCalendar{
+			ID: uuid.New().String(), ConnectionID: conn.ID,
+			ProviderCalendarID: "primary", Name: "Primary", Color: "#000",
+			IsPrimary: true, IsWritable: true, PollBusy: true,
+			CreatedAt: models.Now(), UpdatedAt: models.Now(),
+		}
+		if err := repos.ProviderCalendar.Create(ctx, pc); err != nil {
+			t.Fatalf("create provider calendar: %v", err)
+		}
+		cals[host.ID] = pc.ID
+	}
+
+	owner := hosts[0]
+	tmpl := &models.MeetingTemplate{
+		ID: uuid.New().String(), HostID: owner,
+		Slug: "test-" + short(uuid.New().String()), Name: "Test Template",
+		Durations: models.IntSlice{30}, LocationType: models.ConferencingProviderGoogleMeet,
+		CalendarID: cals[owner], MaxScheduleDays: 30, IsActive: true,
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Template.Create(ctx, tmpl); err != nil {
+		t.Fatalf("create template: %v", err)
+	}
+
+	bk := &models.Booking{
+		ID: uuid.New().String(), TemplateID: tmpl.ID, HostID: owner,
+		Token: uuid.New().String(), Status: models.BookingStatusConfirmed,
+		StartTime: models.Now(), EndTime: models.Now(), Duration: 30,
+		InviteeName: "Inv", InviteeEmail: "i@example.com",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Booking.Create(ctx, bk); err != nil {
+		t.Fatalf("create booking: %v", err)
+	}
+
+	return &fixture{
+		tenantID:   tenant.ID,
+		templateID: tmpl.ID,
+		bookingID:  bk.ID,
+		hostIDs:    hosts,
+		calendars:  cals,
+	}
+}
+
+// repositoryWrapper is just an alias to keep the seed signature compact.
+type repositoryWrapper = repository.Repositories
+
+func basicInput() CalendarEventInput {
+	return CalendarEventInput{
+		Summary:     "Sync test",
+		Description: "Body",
+		Start:       time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC),
+		End:         time.Date(2026, 1, 2, 11, 0, 0, 0, time.UTC),
+		Attendees:   []string{"a@example.com"},
+		HostName:    "Host",
+		HostEmail:   "host@example.com",
+	}
+}
+
+func ownerTarget(fix *fixture) HostTarget {
+	return HostTarget{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true}
+}
+
+func TestSyncerCreate_OneHost_WritesEventAndTrackingRow(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	firstID, link, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: h.fixture.bookingID,
+		Input:  basicInput(),
+		Hosts:  []HostTarget{ownerTarget(h.fixture)},
+	})
+	if err != nil {
+		t.Fatalf("Create returned err: %v", err)
+	}
+	if firstID == "" {
+		t.Fatal("expected non-empty first event ID")
+	}
+	if link != "" {
+		t.Fatalf("expected empty conference link, got %q", link)
+	}
+	if got := len(h.fake.createCalls); got != 1 {
+		t.Fatalf("expected 1 fake create call, got %d", got)
+	}
+	rows, err := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, h.fixture.bookingID)
+	if err != nil {
+		t.Fatalf("GetByBookingID: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 tracking row, got %d", len(rows))
+	}
+	if rows[0].EventID != firstID {
+		t.Fatalf("tracking row event_id = %q, want %q", rows[0].EventID, firstID)
+	}
+}
+
+func TestSyncerCreate_PooledHosts_OneEventPerHost(t *testing.T) {
+	h := makeSyncerHarness(t, 3)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+
+	hosts := []HostTarget{
+		{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true},
+		{HostID: fix.hostIDs[1], CalendarID: fix.calendars[fix.hostIDs[1]]},
+		{HostID: fix.hostIDs[2], CalendarID: fix.calendars[fix.hostIDs[2]]},
+	}
+	firstID, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: fix.bookingID,
+		Input:  basicInput(),
+		Hosts:  hosts,
+	})
+	if err != nil {
+		t.Fatalf("Create returned err: %v", err)
+	}
+	if got := len(h.fake.createCalls); got != 3 {
+		t.Fatalf("expected 3 fake create calls, got %d", got)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 tracking rows, got %d", len(rows))
+	}
+	var ownerRow *models.BookingCalendarEvent
+	for _, r := range rows {
+		if r.HostID == fix.hostIDs[0] {
+			ownerRow = r
+			break
+		}
+	}
+	if ownerRow == nil {
+		t.Fatal("owner tracking row missing")
+	}
+	if firstID != ownerRow.EventID {
+		t.Fatalf("first event ID %q does not match owner tracking row %q", firstID, ownerRow.EventID)
+	}
+}
+
+func TestSyncerCreate_PerHostFailureContinues(t *testing.T) {
+	h := makeSyncerHarness(t, 3)
+	defer h.cleanup()
+	fix := h.fixture
+	failedCal := fix.calendars[fix.hostIDs[1]]
+	h.fake.createErrForCalendarID = map[string]error{failedCal: errors.New("boom")}
+
+	ctx := context.Background()
+	hosts := []HostTarget{
+		{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true},
+		{HostID: fix.hostIDs[1], CalendarID: fix.calendars[fix.hostIDs[1]]},
+		{HostID: fix.hostIDs[2], CalendarID: fix.calendars[fix.hostIDs[2]]},
+	}
+	if _, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: fix.bookingID,
+		Input:  basicInput(),
+		Hosts:  hosts,
+	}); err != nil {
+		t.Fatalf("Create returned err: %v", err)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 tracking rows (failed host skipped), got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.HostID == fix.hostIDs[1] {
+			t.Fatal("failed host should not have a tracking row")
+		}
+	}
+}
+
+func TestSyncerCreate_GoogleMeet_ReturnsConferenceLink(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	h.fake.nextCreate = []fakeCreateResult{
+		{EventID: "g-evt-1", ConferenceLink: "https://meet.google.com/xyz-abc-def"},
+	}
+
+	_, link, err := h.syncer.Create(context.Background(), CalendarSyncRequest{
+		Kind:   ItemKindBooking,
+		ItemID: h.fixture.bookingID,
+		Input:  basicInput(),
+		Hosts:  []HostTarget{ownerTarget(h.fixture)},
+	})
+	if err != nil {
+		t.Fatalf("Create err: %v", err)
+	}
+	if link != "https://meet.google.com/xyz-abc-def" {
+		t.Fatalf("unexpected conference link: %q", link)
+	}
+}
+
+func TestSyncerUpdate_PatchesAllTrackedEvents(t *testing.T) {
+	h := makeSyncerHarness(t, 2)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+
+	hosts := []HostTarget{
+		{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true},
+		{HostID: fix.hostIDs[1], CalendarID: fix.calendars[fix.hostIDs[1]]},
+	}
+	if _, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(), Hosts: hosts,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.fake.updateCalls = nil
+
+	if err := h.syncer.Update(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(),
+	}); err != nil {
+		t.Fatalf("Update err: %v", err)
+	}
+	if got := len(h.fake.updateCalls); got != 2 {
+		t.Fatalf("expected 2 update calls, got %d", got)
+	}
+}
+
+// Replacement event_id from CalDAV-style delete+create path is persisted
+// back to the tracking row.
+func TestSyncerUpdate_CalDAVNewEventID_PersistsToTrackingRow(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+
+	if _, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(),
+		Hosts: []HostTarget{ownerTarget(fix)},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.fake.nextUpdate = []fakeUpdateResult{{EventID: "fresh-id-from-caldav"}}
+
+	if err := h.syncer.Update(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(),
+	}); err != nil {
+		t.Fatalf("Update err: %v", err)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 tracking row, got %d", len(rows))
+	}
+	if rows[0].EventID != "fresh-id-from-caldav" {
+		t.Fatalf("tracking row was not updated to the replacement ID; got %q", rows[0].EventID)
+	}
+}
+
+// When the prior event_id is empty (an earlier create failed and the row was
+// seeded with EventID=""), a subsequent Update must persist whatever new ID
+// the calendar writer returns.
+func TestSyncerUpdate_PriorIDEmpty_PersistsCreatedID(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+	owner := fix.hostIDs[0]
+
+	// Seed a tracking row with EventID="".
+	if err := h.syncer.repos.BookingCalendarEvent.Create(ctx, &models.BookingCalendarEvent{
+		ID:         uuid.New().String(),
+		BookingID:  fix.bookingID,
+		HostID:     owner,
+		CalendarID: fix.calendars[owner],
+		EventID:    "",
+		CreatedAt:  models.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	h.fake.nextUpdate = []fakeUpdateResult{{EventID: "first-create-id"}}
+
+	if err := h.syncer.Update(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(),
+	}); err != nil {
+		t.Fatalf("Update err: %v", err)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 tracking row, got %d", len(rows))
+	}
+	if rows[0].EventID != "first-create-id" {
+		t.Fatalf("tracking row event_id = %q, want first-create-id", rows[0].EventID)
+	}
+}
+
+func TestSyncerDelete_RemovesAllTrackedRows(t *testing.T) {
+	h := makeSyncerHarness(t, 2)
+	defer h.cleanup()
+	ctx := context.Background()
+	fix := h.fixture
+
+	hosts := []HostTarget{
+		{HostID: fix.hostIDs[0], CalendarID: fix.calendars[fix.hostIDs[0]], IsOwner: true},
+		{HostID: fix.hostIDs[1], CalendarID: fix.calendars[fix.hostIDs[1]]},
+	}
+	if _, _, err := h.syncer.Create(ctx, CalendarSyncRequest{
+		Kind: ItemKindBooking, ItemID: fix.bookingID, Input: basicInput(), Hosts: hosts,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.fake.deleteCalls = nil
+
+	count, err := h.syncer.Delete(ctx, ItemKindBooking, fix.bookingID)
+	if err != nil {
+		t.Fatalf("Delete err: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected count=2, got %d", count)
+	}
+	if got := len(h.fake.deleteCalls); got != 2 {
+		t.Fatalf("expected 2 delete calls, got %d", got)
+	}
+	rows, _ := h.syncer.repos.BookingCalendarEvent.GetByBookingID(ctx, fix.bookingID)
+	if len(rows) != 0 {
+		t.Fatalf("expected 0 tracking rows after delete, got %d", len(rows))
+	}
+}
+
+func TestSyncerDelete_NoTrackedRows_ReturnsZero(t *testing.T) {
+	h := makeSyncerHarness(t, 1)
+	defer h.cleanup()
+	count, err := h.syncer.Delete(context.Background(), ItemKindBooking, "no-such-booking")
+	if err != nil {
+		t.Fatalf("Delete err: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected count=0, got %d", count)
+	}
+}

--- a/internal/services/calendar.go
+++ b/internal/services/calendar.go
@@ -566,61 +566,160 @@ func (s *CalendarService) getGoogleBusyTimesMulti(ctx context.Context, conn *mod
 	return out, nil
 }
 
-// CreateEvent creates a calendar event in the template's configured calendar.
-// details.Template.CalendarID is interpreted as a provider_calendars.id.
+// CalendarEventInput is the provider-agnostic shape of a calendar event the
+// caller wants written. Booking and hosted-event flows both build one of these
+// and hand it to CreateEventForHost / UpdateEvent.
+//
+// Description must be already-composed by the caller — providers render it
+// verbatim. The booking-side adapter (BuildCalendarEventInputForBooking)
+// composes the agenda and reschedule-link suffixes that booking flows need;
+// the hosted-event flow does not.
+type CalendarEventInput struct {
+	Summary            string
+	Description        string
+	Start              time.Time
+	End                time.Time
+	LocationType       models.ConferencingProvider
+	CustomLocation     string
+	ConferenceLink     string
+	Attendees          []string
+	HostName           string
+	HostEmail          string
+	EventID            string // empty for create; set for update
+	MeetIdempotencyKey string // requestId for Google Meet conferenceData.createRequest
+}
+
+// calendarEventWriter is the narrow contract that CalendarEventSyncer depends
+// on. *CalendarService satisfies it; tests inject a fake.
+type calendarEventWriter interface {
+	CreateEventForHost(ctx context.Context, providerCalendarID string, input *CalendarEventInput) (eventID, conferenceLink string, err error)
+	UpdateEvent(ctx context.Context, providerCalendarID string, input *CalendarEventInput) (eventID string, err error)
+	DeleteEvent(ctx context.Context, hostID, providerCalendarID, eventID string) error
+}
+
+// BuildCalendarEventInputForBooking composes a CalendarEventInput from a
+// BookingWithDetails. Description includes the template description, any
+// invitee-supplied agenda, host notes (when surfacing on update), and the
+// reschedule link — i.e. what the previous booking-coupled providers used to
+// build inline.
+func (s *CalendarService) BuildCalendarEventInputForBooking(details *BookingWithDetails) *CalendarEventInput {
+	attendees := make([]string, 0, 1+len(details.Booking.AdditionalGuests))
+	if details.Booking.InviteeEmail != "" {
+		attendees = append(attendees, details.Booking.InviteeEmail)
+	}
+	for _, guest := range details.Booking.AdditionalGuests {
+		if isValidEmail(guest) {
+			attendees = append(attendees, guest)
+		}
+	}
+
+	description := details.Template.Description
+	if details.Booking.Answers != nil {
+		if agenda, ok := details.Booking.Answers["agenda"].(string); ok && agenda != "" {
+			if description != "" {
+				description += "\n\n"
+			}
+			description += "Agenda:\n" + agenda
+		}
+		if notes, ok := details.Booking.Answers["host_notes"].(string); ok && notes != "" {
+			if description != "" {
+				description += "\n\n"
+			}
+			description += "Notes from host:\n" + notes
+		}
+	}
+	rescheduleURL := fmt.Sprintf("%s/m/%s/%s/%s/reschedule/%s",
+		s.cfg.Server.BaseURL, details.Tenant.Slug, details.Host.Slug, details.Template.Slug, details.Booking.ID)
+	if description != "" {
+		description += "\n\n"
+	}
+	description += "Reschedule this meeting:\n" + rescheduleURL
+
+	return &CalendarEventInput{
+		Summary:            details.Template.Name + " with " + details.Booking.InviteeName,
+		Description:        description,
+		Start:              details.Booking.StartTime.Time,
+		End:                details.Booking.EndTime.Time,
+		LocationType:       details.Template.LocationType,
+		CustomLocation:     details.Template.CustomLocation,
+		ConferenceLink:     details.Booking.ConferenceLink,
+		Attendees:          attendees,
+		HostName:           details.Host.Name,
+		HostEmail:          details.Host.Email,
+		EventID:            details.Booking.CalendarEventID,
+		MeetIdempotencyKey: details.Booking.ID,
+	}
+}
+
+// CreateEvent is the booking-side adapter for legacy single-host call sites
+// that still hand over a *BookingWithDetails. Builds an input and delegates.
+// The returned conferenceLink is also written onto details.Booking.ConferenceLink
+// when Google Meet creation surfaces one.
 func (s *CalendarService) CreateEvent(ctx context.Context, details *BookingWithDetails) (string, error) {
-	return s.CreateEventForHost(ctx, details, details.Template.CalendarID)
+	input := s.BuildCalendarEventInputForBooking(details)
+	eventID, conferenceLink, err := s.CreateEventForHost(ctx, details.Template.CalendarID, input)
+	if err != nil {
+		return "", err
+	}
+	if conferenceLink != "" && details.Booking.ConferenceLink == "" {
+		details.Booking.ConferenceLink = conferenceLink
+	}
+	return eventID, nil
 }
 
 // CreateEventForHost creates a calendar event in a specific provider calendar.
-func (s *CalendarService) CreateEventForHost(ctx context.Context, details *BookingWithDetails, providerCalendarID string) (string, error) {
+// Returns (eventID, conferenceLink, error). conferenceLink is non-empty only
+// when Google Meet creation succeeded as part of the create call.
+func (s *CalendarService) CreateEventForHost(ctx context.Context, providerCalendarID string, input *CalendarEventInput) (string, string, error) {
 	if providerCalendarID == "" {
-		return "", nil
+		return "", "", nil
 	}
 
 	pc, err := s.repos.ProviderCalendar.GetByID(ctx, providerCalendarID)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if pc == nil {
-		return "", ErrCalendarNotFound
+		return "", "", ErrCalendarNotFound
 	}
 	if !pc.IsWritable {
-		return "", fmt.Errorf("calendar %s is not writable", pc.Name)
+		return "", "", fmt.Errorf("calendar %s is not writable", pc.Name)
 	}
 	conn, err := s.repos.Calendar.GetByID(ctx, pc.ConnectionID)
 	if err != nil || conn == nil {
-		return "", ErrCalendarNotFound
+		return "", "", ErrCalendarNotFound
 	}
 
 	view := *conn
 	switch conn.Provider {
 	case models.CalendarProviderGoogle:
 		view.CalendarID = pc.ProviderCalendarID
-		return s.createGoogleEvent(ctx, &view, details)
+		return s.createGoogleEvent(ctx, &view, input)
 	case models.CalendarProviderCalDAV, models.CalendarProviderICloud:
 		if pc.ProviderCalendarID != "" {
 			view.CalDAVURL = pc.ProviderCalendarID
 		}
-		return s.createCalDAVEvent(ctx, &view, details)
+		eventID, err := s.createCalDAVEvent(ctx, &view, input)
+		return eventID, "", err
 	}
-	return "", nil
+	return "", "", nil
 }
 
-// UpdateEvent updates an existing calendar event for a booking. If the booking
-// has no recorded event ID (e.g. event creation previously failed), falls back
-// to CreateEventForHost so reconnect-then-edit produces a fresh event.
+// UpdateEvent updates an existing calendar event. If input.EventID is empty
+// (e.g. event creation previously failed), falls back to CreateEventForHost so
+// reconnect-then-edit produces a fresh event — and the new event ID is
+// returned to the caller, which is responsible for persisting it.
 //
-// For Google: issues a PATCH so existing attendees keep their RSVP state and
-// get a single "event updated" invitation. For CalDAV: replaces the event via
-// delete + create (CalDAV does not have a clean PATCH primitive in this
-// codebase; the resulting iCal carries the new state to all attendees).
-func (s *CalendarService) UpdateEvent(ctx context.Context, details *BookingWithDetails, providerCalendarID string) (string, error) {
-	if details.Booking.CalendarEventID == "" {
-		return s.CreateEventForHost(ctx, details, providerCalendarID)
+// For Google: PATCH so existing attendees keep their RSVP state. For CalDAV:
+// replaces the event via delete + create; the new ID is returned and may
+// differ from input.EventID.
+func (s *CalendarService) UpdateEvent(ctx context.Context, providerCalendarID string, input *CalendarEventInput) (string, error) {
+	if input.EventID == "" {
+		eventID, _, err := s.CreateEventForHost(ctx, providerCalendarID, input)
+		return eventID, err
 	}
 	if providerCalendarID == "" {
-		return details.Booking.CalendarEventID, nil
+		return input.EventID, nil
 	}
 
 	pc, err := s.repos.ProviderCalendar.GetByID(ctx, providerCalendarID)
@@ -639,22 +738,21 @@ func (s *CalendarService) UpdateEvent(ctx context.Context, details *BookingWithD
 	switch conn.Provider {
 	case models.CalendarProviderGoogle:
 		view.CalendarID = pc.ProviderCalendarID
-		return s.updateGoogleEvent(ctx, &view, details)
+		return s.updateGoogleEvent(ctx, &view, input)
 	case models.CalendarProviderCalDAV, models.CalendarProviderICloud:
 		if pc.ProviderCalendarID != "" {
 			view.CalDAVURL = pc.ProviderCalendarID
 		}
-		// CalDAV: replace via delete + create.
-		if err := s.deleteCalDAVEvent(ctx, &view, details.Booking.CalendarEventID); err != nil {
+		if err := s.deleteCalDAVEvent(ctx, &view, input.EventID); err != nil {
 			log.Printf("[CALENDAR] CalDAV delete during update failed: %v", err)
 		}
-		newID, err := s.createCalDAVEvent(ctx, &view, details)
+		newID, err := s.createCalDAVEvent(ctx, &view, input)
 		if err != nil {
 			return "", err
 		}
 		return newID, nil
 	}
-	return details.Booking.CalendarEventID, nil
+	return input.EventID, nil
 }
 
 // DeleteEvent deletes a calendar event from a provider calendar.
@@ -992,71 +1090,50 @@ func (s *CalendarService) getGoogleBusyTimes(ctx context.Context, cal *models.Ca
 	return busyTimes, nil
 }
 
-func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.CalendarConnection, details *BookingWithDetails) (string, error) {
+func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.CalendarConnection, input *CalendarEventInput) (string, string, error) {
 	if err := s.refreshGoogleToken(cal); err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	// Build attendees list, filtering out invalid emails
-	attendees := []map[string]string{
-		{"email": details.Booking.InviteeEmail},
-	}
-	for _, guest := range details.Booking.AdditionalGuests {
-		// Basic email validation - must contain @ and have content on both sides
-		if strings.Contains(guest, "@") && len(strings.Split(guest, "@")[0]) > 0 && len(strings.Split(guest, "@")[1]) > 1 {
-			attendees = append(attendees, map[string]string{"email": guest})
+	attendees := make([]map[string]string, 0, len(input.Attendees))
+	for _, email := range input.Attendees {
+		if isValidEmail(email) {
+			attendees = append(attendees, map[string]string{"email": email})
 		}
 	}
-
-	// Build description with template description and agenda if provided
-	description := details.Template.Description
-	if details.Booking.Answers != nil {
-		if agenda, ok := details.Booking.Answers["agenda"].(string); ok && agenda != "" {
-			if description != "" {
-				description += "\n\n"
-			}
-			description += "Agenda:\n" + agenda
-		}
-	}
-
-	// Add reschedule link
-	rescheduleURL := fmt.Sprintf("%s/m/%s/%s/%s/reschedule/%s",
-		s.cfg.Server.BaseURL, details.Tenant.Slug, details.Host.Slug, details.Template.Slug, details.Booking.ID)
-	if description != "" {
-		description += "\n\n"
-	}
-	description += "Reschedule this meeting:\n" + rescheduleURL
 
 	event := map[string]interface{}{
-		"summary":     details.Template.Name + " with " + details.Booking.InviteeName,
-		"description": description,
+		"summary":     input.Summary,
+		"description": input.Description,
 		"start": map[string]string{
-			"dateTime": details.Booking.StartTime.Format(time.RFC3339),
+			"dateTime": input.Start.Format(time.RFC3339),
 			"timeZone": "UTC",
 		},
 		"end": map[string]string{
-			"dateTime": details.Booking.EndTime.Format(time.RFC3339),
+			"dateTime": input.End.Format(time.RFC3339),
 			"timeZone": "UTC",
 		},
 		"attendees": attendees,
 	}
 
-	// Add location based on location type
-	if details.Template.LocationType == models.ConferencingProviderPhone {
-		if details.Template.CustomLocation != "" {
-			event["location"] = "Call " + details.Template.CustomLocation
+	if input.LocationType == models.ConferencingProviderPhone {
+		if input.CustomLocation != "" {
+			event["location"] = "Call " + input.CustomLocation
 		}
-	} else if details.Booking.ConferenceLink != "" {
-		event["location"] = details.Booking.ConferenceLink
-	} else if details.Template.CustomLocation != "" {
-		event["location"] = details.Template.CustomLocation
+	} else if input.ConferenceLink != "" {
+		event["location"] = input.ConferenceLink
+	} else if input.CustomLocation != "" {
+		event["location"] = input.CustomLocation
 	}
 
-	// Add Google Meet if that's the location type and no link exists
-	if details.Template.LocationType == models.ConferencingProviderGoogleMeet && details.Booking.ConferenceLink == "" {
+	if input.LocationType == models.ConferencingProviderGoogleMeet && input.ConferenceLink == "" {
+		key := input.MeetIdempotencyKey
+		if key == "" {
+			key = uuid.New().String()
+		}
 		event["conferenceData"] = map[string]interface{}{
 			"createRequest": map[string]string{
-				"requestId": details.Booking.ID,
+				"requestId": key,
 			},
 		}
 	}
@@ -1070,7 +1147,7 @@ func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.Cal
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -1080,7 +1157,7 @@ func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.Cal
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("failed to create event: %s", string(respBody))
+		return "", "", fmt.Errorf("failed to create event: %s", string(respBody))
 	}
 
 	var result struct {
@@ -1092,68 +1169,44 @@ func (s *CalendarService) createGoogleEvent(ctx context.Context, cal *models.Cal
 		} `json:"conferenceData"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	// Update conference link if Google Meet was created
-	if len(result.ConferenceData.EntryPoints) > 0 && details.Booking.ConferenceLink == "" {
-		details.Booking.ConferenceLink = result.ConferenceData.EntryPoints[0].URI
+	conferenceLink := ""
+	if len(result.ConferenceData.EntryPoints) > 0 && input.ConferenceLink == "" {
+		conferenceLink = result.ConferenceData.EntryPoints[0].URI
 	}
 
-	return result.ID, nil
+	return result.ID, conferenceLink, nil
 }
 
 // updateGoogleEvent PATCHes an existing Google Calendar event. The patch body
 // only includes mutable fields (description, location, attendees) — title and
 // time are left unchanged so this method composes safely with reschedule
 // (which deletes and recreates rather than patches).
-func (s *CalendarService) updateGoogleEvent(ctx context.Context, cal *models.CalendarConnection, details *BookingWithDetails) (string, error) {
+func (s *CalendarService) updateGoogleEvent(ctx context.Context, cal *models.CalendarConnection, input *CalendarEventInput) (string, error) {
 	if err := s.refreshGoogleToken(cal); err != nil {
 		return "", err
 	}
 
-	attendees := []map[string]string{
-		{"email": details.Booking.InviteeEmail},
-	}
-	for _, guest := range details.Booking.AdditionalGuests {
-		if strings.Contains(guest, "@") && len(strings.Split(guest, "@")[0]) > 0 && len(strings.Split(guest, "@")[1]) > 1 {
-			attendees = append(attendees, map[string]string{"email": guest})
+	attendees := make([]map[string]string, 0, len(input.Attendees))
+	for _, email := range input.Attendees {
+		if isValidEmail(email) {
+			attendees = append(attendees, map[string]string{"email": email})
 		}
 	}
-
-	description := details.Template.Description
-	if details.Booking.Answers != nil {
-		if agenda, ok := details.Booking.Answers["agenda"].(string); ok && agenda != "" {
-			if description != "" {
-				description += "\n\n"
-			}
-			description += "Agenda:\n" + agenda
-		}
-		if notes, ok := details.Booking.Answers["host_notes"].(string); ok && notes != "" {
-			if description != "" {
-				description += "\n\n"
-			}
-			description += "Notes from host:\n" + notes
-		}
-	}
-	rescheduleURL := fmt.Sprintf("%s/m/%s/%s/%s/reschedule/%s",
-		s.cfg.Server.BaseURL, details.Tenant.Slug, details.Host.Slug, details.Template.Slug, details.Booking.ID)
-	if description != "" {
-		description += "\n\n"
-	}
-	description += "Reschedule this meeting:\n" + rescheduleURL
 
 	patch := map[string]interface{}{
-		"description": description,
+		"description": input.Description,
 		"attendees":   attendees,
 	}
-	if details.Booking.ConferenceLink != "" {
-		patch["location"] = details.Booking.ConferenceLink
+	if input.ConferenceLink != "" {
+		patch["location"] = input.ConferenceLink
 	}
 
 	body, _ := json.Marshal(patch)
 	patchURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events/%s?sendUpdates=all",
-		url.PathEscape(cal.CalendarID), url.PathEscape(details.Booking.CalendarEventID))
+		url.PathEscape(cal.CalendarID), url.PathEscape(input.EventID))
 
 	req, _ := http.NewRequest("PATCH", patchURL, strings.NewReader(string(body)))
 	req.Header.Set("Authorization", "Bearer "+cal.AccessToken)
@@ -1174,7 +1227,7 @@ func (s *CalendarService) updateGoogleEvent(ctx context.Context, cal *models.Cal
 		return "", fmt.Errorf("failed to update event: %s", string(respBody))
 	}
 
-	return details.Booking.CalendarEventID, nil
+	return input.EventID, nil
 }
 
 func (s *CalendarService) deleteGoogleEvent(ctx context.Context, cal *models.CalendarConnection, eventID string) error {
@@ -1568,41 +1621,31 @@ func parseICSDuration(line string) (time.Duration, bool) {
 	return duration, duration > 0
 }
 
-func (s *CalendarService) createCalDAVEvent(ctx context.Context, cal *models.CalendarConnection, details *BookingWithDetails) (string, error) {
+func (s *CalendarService) createCalDAVEvent(ctx context.Context, cal *models.CalendarConnection, input *CalendarEventInput) (string, error) {
 	eventUID := uuid.New().String()
 
-	// Build location string
 	location := ""
-	if details.Template.LocationType == models.ConferencingProviderPhone {
-		if details.Template.CustomLocation != "" {
-			location = "Call " + details.Template.CustomLocation
+	if input.LocationType == models.ConferencingProviderPhone {
+		if input.CustomLocation != "" {
+			location = "Call " + input.CustomLocation
 		}
-	} else if details.Booking.ConferenceLink != "" {
-		location = details.Booking.ConferenceLink
-	} else if details.Template.CustomLocation != "" {
-		location = details.Template.CustomLocation
+	} else if input.ConferenceLink != "" {
+		location = input.ConferenceLink
+	} else if input.CustomLocation != "" {
+		location = input.CustomLocation
 	}
 
-	// Build description with template description and agenda if provided
-	description := details.Template.Description
-	if details.Booking.Answers != nil {
-		if agenda, ok := details.Booking.Answers["agenda"].(string); ok && agenda != "" {
-			if description != "" {
-				description += "\\n\\n"
-			}
-			description += "Agenda:\\n" + strings.ReplaceAll(agenda, "\n", "\\n")
+	// iCalendar requires literal "\n" sequences (escaped) in DESCRIPTION; the
+	// caller composes the description with real newlines, we escape here.
+	icsDescription := strings.ReplaceAll(input.Description, "\n", "\\n")
+
+	var attendeeLines string
+	for _, email := range input.Attendees {
+		if isValidEmail(email) {
+			attendeeLines += fmt.Sprintf("\nATTENDEE:mailto:%s", email)
 		}
 	}
 
-	// Add reschedule link
-	rescheduleURL := fmt.Sprintf("%s/m/%s/%s/%s/reschedule/%s",
-		s.cfg.Server.BaseURL, details.Tenant.Slug, details.Host.Slug, details.Template.Slug, details.Booking.ID)
-	if description != "" {
-		description += "\\n\\n"
-	}
-	description += "Reschedule this meeting:\\n" + rescheduleURL
-
-	// Build iCalendar event
 	ics := fmt.Sprintf(`BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//MeetWhen//EN
@@ -1613,18 +1656,17 @@ DTEND:%s
 SUMMARY:%s
 DESCRIPTION:%s
 LOCATION:%s
-ORGANIZER:mailto:%s
-ATTENDEE:mailto:%s
+ORGANIZER:mailto:%s%s
 END:VEVENT
 END:VCALENDAR`,
 		eventUID,
-		details.Booking.StartTime.UTC().Format("20060102T150405Z"),
-		details.Booking.EndTime.UTC().Format("20060102T150405Z"),
-		details.Template.Name+" with "+details.Booking.InviteeName,
-		description,
+		input.Start.UTC().Format("20060102T150405Z"),
+		input.End.UTC().Format("20060102T150405Z"),
+		input.Summary,
+		icsDescription,
 		location,
-		details.Host.Email,
-		details.Booking.InviteeEmail,
+		input.HostEmail,
+		attendeeLines,
 	)
 
 	eventURL := fmt.Sprintf("%s/%s.ics", strings.TrimSuffix(cal.CalDAVURL, "/"), eventUID)

--- a/internal/services/calendar_eventsync.go
+++ b/internal/services/calendar_eventsync.go
@@ -64,15 +64,15 @@ type CalendarEventSyncer struct {
 	stores   map[ScheduledItemKind]trackingStore
 }
 
-// NewCalendarEventSyncer constructs the syncer. Currently only the booking
-// kind is wired; the hosted-event kind is registered when its tracking
-// repository lands in Phase B.
+// NewCalendarEventSyncer constructs the syncer with both kind dispatchers
+// wired.
 func NewCalendarEventSyncer(repos *repository.Repositories, calendar calendarEventWriter) *CalendarEventSyncer {
 	return &CalendarEventSyncer{
 		repos:    repos,
 		calendar: calendar,
 		stores: map[ScheduledItemKind]trackingStore{
-			ItemKindBooking: &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+			ItemKindBooking:     &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+			ItemKindHostedEvent: &hostedEventTrackingStore{repo: repos.HostedEventCalendarEvent},
 		},
 	}
 }
@@ -268,4 +268,49 @@ func (b *bookingTrackingStore) updateEventID(ctx context.Context, rowID, newEven
 
 func (b *bookingTrackingStore) deleteByItemID(ctx context.Context, itemID string) error {
 	return b.repo.DeleteByBookingID(ctx, itemID)
+}
+
+// hostedEventTrackingStore adapts HostedEventCalendarEventRepository.
+type hostedEventTrackingStore struct {
+	repo *repository.HostedEventCalendarEventRepository
+}
+
+func (h *hostedEventTrackingStore) create(ctx context.Context, itemID, hostID, calendarID, eventID string) error {
+	return h.repo.Create(ctx, &models.HostedEventCalendarEvent{
+		ID:            uuid.New().String(),
+		HostedEventID: itemID,
+		HostID:        hostID,
+		CalendarID:    calendarID,
+		EventID:       eventID,
+		CreatedAt:     models.Now(),
+	})
+}
+
+func (h *hostedEventTrackingStore) listByItemID(ctx context.Context, itemID string) ([]trackingRow, error) {
+	events, err := h.repo.GetByHostedEventID(ctx, itemID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]trackingRow, 0, len(events))
+	for _, e := range events {
+		out = append(out, trackingRow{
+			ID:         e.ID,
+			HostID:     e.HostID,
+			CalendarID: e.CalendarID,
+			EventID:    e.EventID,
+		})
+	}
+	return out, nil
+}
+
+func (h *hostedEventTrackingStore) updateEventID(ctx context.Context, rowID, newEventID, newCalendarID string) error {
+	return h.repo.Update(ctx, &models.HostedEventCalendarEvent{
+		ID:         rowID,
+		EventID:    newEventID,
+		CalendarID: newCalendarID,
+	})
+}
+
+func (h *hostedEventTrackingStore) deleteByItemID(ctx context.Context, itemID string) error {
+	return h.repo.DeleteByHostedEventID(ctx, itemID)
 }

--- a/internal/services/calendar_eventsync.go
+++ b/internal/services/calendar_eventsync.go
@@ -1,0 +1,271 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/models"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// ScheduledItemKind identifies what kind of scheduled item a CalendarSyncRequest
+// belongs to. The syncer routes tracking-table writes off this value.
+type ScheduledItemKind string
+
+const (
+	ItemKindBooking     ScheduledItemKind = "booking"
+	ItemKindHostedEvent ScheduledItemKind = "hosted_event"
+)
+
+// HostTarget identifies one host's calendar that an event should be written to.
+type HostTarget struct {
+	HostID     string
+	CalendarID string // empty → resolve via host default + first writable
+	IsOwner    bool
+}
+
+// CalendarSyncRequest is the unified shape that BookingService and
+// HostedEventService hand to the syncer.
+type CalendarSyncRequest struct {
+	Kind   ScheduledItemKind
+	ItemID string
+	Input  CalendarEventInput
+	Hosts  []HostTarget
+}
+
+// trackingRow is the syncer's view of a row in either booking_calendar_events
+// or hosted_event_calendar_events. It's the minimum information the syncer
+// needs to update or delete provider events.
+type trackingRow struct {
+	ID         string
+	HostID     string
+	CalendarID string
+	EventID    string
+}
+
+// trackingStore abstracts the per-kind tracking table the syncer writes to.
+// One implementation per ScheduledItemKind.
+type trackingStore interface {
+	create(ctx context.Context, itemID, hostID, calendarID, eventID string) error
+	listByItemID(ctx context.Context, itemID string) ([]trackingRow, error)
+	updateEventID(ctx context.Context, rowID, newEventID, newCalendarID string) error
+	deleteByItemID(ctx context.Context, itemID string) error
+}
+
+// CalendarEventSyncer fans calendar create/update/delete out across one or
+// more host calendars and persists tracking rows. Replaces the duplicated
+// per-host logic that previously lived inside BookingService.
+type CalendarEventSyncer struct {
+	repos    *repository.Repositories
+	calendar calendarEventWriter
+	stores   map[ScheduledItemKind]trackingStore
+}
+
+// NewCalendarEventSyncer constructs the syncer. Currently only the booking
+// kind is wired; the hosted-event kind is registered when its tracking
+// repository lands in Phase B.
+func NewCalendarEventSyncer(repos *repository.Repositories, calendar calendarEventWriter) *CalendarEventSyncer {
+	return &CalendarEventSyncer{
+		repos:    repos,
+		calendar: calendar,
+		stores: map[ScheduledItemKind]trackingStore{
+			ItemKindBooking: &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+		},
+	}
+}
+
+// resolveWritableCalendarID returns the calendar ID to write to for a host:
+// preferredID if non-empty, else the host's default, else the first writable
+// provider calendar. Returns ("", error) only on lookup error; ("", nil) means
+// no writable calendar exists for this host (caller should skip).
+func (s *CalendarEventSyncer) resolveWritableCalendarID(ctx context.Context, hostID, preferredID string) (string, error) {
+	if preferredID != "" {
+		return preferredID, nil
+	}
+	host, err := s.repos.Host.GetByID(ctx, hostID)
+	if err != nil {
+		return "", err
+	}
+	if host != nil && host.DefaultCalendarID != nil && *host.DefaultCalendarID != "" {
+		return *host.DefaultCalendarID, nil
+	}
+	pcs, err := s.repos.ProviderCalendar.GetByHostID(ctx, hostID)
+	if err != nil {
+		return "", err
+	}
+	for _, pc := range pcs {
+		if pc.IsWritable {
+			return pc.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// Create writes the calendar event for every host target and persists one
+// tracking row per success. Returns the first non-empty event ID (used as the
+// "primary" ID by callers that keep a legacy single-event-id column) and the
+// first non-empty conference link surfaced by the create response (Google
+// Meet path). Per-host errors are logged but do not abort the batch — matches
+// the prior booking behaviour.
+func (s *CalendarEventSyncer) Create(ctx context.Context, req CalendarSyncRequest) (string, string, error) {
+	store, err := s.storeFor(req.Kind)
+	if err != nil {
+		return "", "", err
+	}
+
+	var firstEventID, firstConferenceLink string
+	for _, target := range req.Hosts {
+		calendarID, err := s.resolveWritableCalendarID(ctx, target.HostID, target.CalendarID)
+		if err != nil {
+			log.Printf("[SYNC] Error resolving calendar for host %s: %v", target.HostID, err)
+			continue
+		}
+		if calendarID == "" {
+			log.Printf("[SYNC] No writable calendar for host %s, skipping event creation", target.HostID)
+			continue
+		}
+
+		// The provider may need the per-host EventID empty (always for create).
+		input := req.Input
+		input.EventID = ""
+
+		eventID, conferenceLink, err := s.calendar.CreateEventForHost(ctx, calendarID, &input)
+		if err != nil {
+			log.Printf("[SYNC] Error creating calendar event for host %s: %v", target.HostID, err)
+			continue
+		}
+		if eventID == "" {
+			continue
+		}
+
+		if err := store.create(ctx, req.ItemID, target.HostID, calendarID, eventID); err != nil {
+			log.Printf("[SYNC] Error writing tracking row for %s/%s: %v", req.Kind, req.ItemID, err)
+		}
+
+		if firstEventID == "" && target.IsOwner {
+			firstEventID = eventID
+			firstConferenceLink = conferenceLink
+		} else if firstEventID == "" {
+			firstEventID = eventID
+			firstConferenceLink = conferenceLink
+		}
+	}
+	return firstEventID, firstConferenceLink, nil
+}
+
+// Update patches every tracked calendar event for the item. If a provider's
+// update returns a replacement event ID (CalDAV delete+create, or the
+// fallback-to-create path when the prior ID was empty), the tracking row is
+// updated in place — without this, subsequent updates / deletes would target
+// stale events.
+func (s *CalendarEventSyncer) Update(ctx context.Context, req CalendarSyncRequest) error {
+	store, err := s.storeFor(req.Kind)
+	if err != nil {
+		return err
+	}
+
+	rows, err := store.listByItemID(ctx, req.ItemID)
+	if err != nil {
+		return fmt.Errorf("list tracking rows: %w", err)
+	}
+
+	for _, row := range rows {
+		input := req.Input
+		input.EventID = row.EventID
+
+		newID, err := s.calendar.UpdateEvent(ctx, row.CalendarID, &input)
+		if err != nil {
+			log.Printf("[SYNC] Error updating calendar event %s for host %s: %v", row.EventID, row.HostID, err)
+			continue
+		}
+		if newID != "" && newID != row.EventID {
+			if err := store.updateEventID(ctx, row.ID, newID, row.CalendarID); err != nil {
+				log.Printf("[SYNC] Error persisting replacement event ID for %s/%s: %v", req.Kind, req.ItemID, err)
+			}
+		}
+	}
+	return nil
+}
+
+// Delete removes the calendar event for every host target and clears the
+// tracking rows. Returns the number of tracking rows that existed (callers
+// can branch on 0 to fall back to legacy single-host paths).
+func (s *CalendarEventSyncer) Delete(ctx context.Context, kind ScheduledItemKind, itemID string) (int, error) {
+	store, err := s.storeFor(kind)
+	if err != nil {
+		return 0, err
+	}
+
+	rows, err := store.listByItemID(ctx, itemID)
+	if err != nil {
+		return 0, fmt.Errorf("list tracking rows: %w", err)
+	}
+
+	for _, row := range rows {
+		if err := s.calendar.DeleteEvent(ctx, row.HostID, row.CalendarID, row.EventID); err != nil {
+			log.Printf("[SYNC] Error deleting calendar event %s for host %s: %v", row.EventID, row.HostID, err)
+		}
+	}
+	if len(rows) > 0 {
+		if err := store.deleteByItemID(ctx, itemID); err != nil {
+			log.Printf("[SYNC] Error clearing tracking rows for %s/%s: %v", kind, itemID, err)
+		}
+	}
+	return len(rows), nil
+}
+
+func (s *CalendarEventSyncer) storeFor(kind ScheduledItemKind) (trackingStore, error) {
+	store, ok := s.stores[kind]
+	if !ok {
+		return nil, errors.New("no tracking store registered for kind " + string(kind))
+	}
+	return store, nil
+}
+
+// bookingTrackingStore adapts BookingCalendarEventRepository to trackingStore.
+type bookingTrackingStore struct {
+	repo *repository.BookingCalendarEventRepository
+}
+
+func (b *bookingTrackingStore) create(ctx context.Context, itemID, hostID, calendarID, eventID string) error {
+	return b.repo.Create(ctx, &models.BookingCalendarEvent{
+		ID:         uuid.New().String(),
+		BookingID:  itemID,
+		HostID:     hostID,
+		CalendarID: calendarID,
+		EventID:    eventID,
+		CreatedAt:  models.Now(),
+	})
+}
+
+func (b *bookingTrackingStore) listByItemID(ctx context.Context, itemID string) ([]trackingRow, error) {
+	events, err := b.repo.GetByBookingID(ctx, itemID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]trackingRow, 0, len(events))
+	for _, e := range events {
+		out = append(out, trackingRow{
+			ID:         e.ID,
+			HostID:     e.HostID,
+			CalendarID: e.CalendarID,
+			EventID:    e.EventID,
+		})
+	}
+	return out, nil
+}
+
+func (b *bookingTrackingStore) updateEventID(ctx context.Context, rowID, newEventID, newCalendarID string) error {
+	return b.repo.Update(ctx, &models.BookingCalendarEvent{
+		ID:         rowID,
+		EventID:    newEventID,
+		CalendarID: newCalendarID,
+	})
+}
+
+func (b *bookingTrackingStore) deleteByItemID(ctx context.Context, itemID string) error {
+	return b.repo.DeleteByBookingID(ctx, itemID)
+}

--- a/internal/services/conferencing.go
+++ b/internal/services/conferencing.go
@@ -39,18 +39,35 @@ func NewConferencingService(cfg *config.Config, repos *repository.Repositories) 
 	}
 }
 
-// CreateMeeting creates a video conference meeting
+// CreateMeeting creates a video conference meeting for a booking. Kept on
+// the original signature; delegates to the booking-shape-agnostic raw helper
+// for the Zoom path so HostedEventService can reuse the same plumbing.
 func (s *ConferencingService) CreateMeeting(ctx context.Context, details *BookingWithDetails) (string, error) {
 	switch details.Template.LocationType {
 	case models.ConferencingProviderGoogleMeet:
 		// Google Meet is handled by calendar event creation
 		return "", nil
 	case models.ConferencingProviderZoom:
-		return s.createZoomMeeting(ctx, details)
+		topic := details.Template.Name + " with " + details.Booking.InviteeName
+		return s.createZoomMeetingRaw(ctx, details.Booking.HostID, topic, details.Booking.StartTime.Time, details.Booking.Duration)
 	case models.ConferencingProviderPhone:
 		return details.Template.CustomLocation, nil
 	case models.ConferencingProviderCustom:
 		return details.Template.CustomLocation, nil
+	}
+	return "", nil
+}
+
+// CreateMeetingForHostedEvent is the host-driven equivalent of CreateMeeting.
+// Returns the conference link (or "") for the requested location type.
+func (s *ConferencingService) CreateMeetingForHostedEvent(ctx context.Context, hostID, title string, start time.Time, durationMin int, locationType models.ConferencingProvider, customLocation string) (string, error) {
+	switch locationType {
+	case models.ConferencingProviderGoogleMeet:
+		return "", nil
+	case models.ConferencingProviderZoom:
+		return s.createZoomMeetingRaw(ctx, hostID, title, start, durationMin)
+	case models.ConferencingProviderPhone, models.ConferencingProviderCustom:
+		return customLocation, nil
 	}
 	return "", nil
 }
@@ -250,8 +267,10 @@ func (s *ConferencingService) refreshZoomToken(ctx context.Context, conn *models
 	return s.repos.Conferencing.Update(ctx, conn)
 }
 
-func (s *ConferencingService) createZoomMeeting(ctx context.Context, details *BookingWithDetails) (string, error) {
-	conn, err := s.repos.Conferencing.GetByHostAndProvider(ctx, details.Booking.HostID, models.ConferencingProviderZoom)
+// createZoomMeetingRaw is the shape-agnostic Zoom meeting creator. Used by
+// both booking and hosted-event flows. Returns the meeting join URL.
+func (s *ConferencingService) createZoomMeetingRaw(ctx context.Context, hostID, topic string, start time.Time, durationMin int) (string, error) {
+	conn, err := s.repos.Conferencing.GetByHostAndProvider(ctx, hostID, models.ConferencingProviderZoom)
 	if err != nil || conn == nil {
 		return "", ErrConferencingReauthRequired
 	}
@@ -261,10 +280,10 @@ func (s *ConferencingService) createZoomMeeting(ctx context.Context, details *Bo
 	}
 
 	meeting := map[string]interface{}{
-		"topic":      details.Template.Name + " with " + details.Booking.InviteeName,
+		"topic":      topic,
 		"type":       2, // Scheduled meeting
-		"start_time": details.Booking.StartTime.Format("2006-01-02T15:04:05Z"),
-		"duration":   details.Booking.Duration,
+		"start_time": start.UTC().Format("2006-01-02T15:04:05Z"),
+		"duration":   durationMin,
 		"timezone":   "UTC",
 		"settings": map[string]interface{}{
 			"host_video":        true,

--- a/internal/services/contact.go
+++ b/internal/services/contact.go
@@ -59,6 +59,32 @@ func (s *ContactService) UpsertFromBooking(ctx context.Context, details *Booking
 	}
 }
 
+// UpsertFromHostedEventAttendee creates or updates a contact from a hosted-
+// event attendee. The caller is expected to invoke this only for newly added
+// attendees on create / on update — not for retained attendees on edit, so
+// meeting_count and last_met don't get re-incremented from a benign edit.
+// Errors are logged but do not propagate, mirroring UpsertFromBooking.
+func (s *ContactService) UpsertFromHostedEventAttendee(ctx context.Context, tenantID string, email, name string, eventStart models.SQLiteTime) {
+	if tenantID == "" || email == "" {
+		return
+	}
+	now := models.Now()
+	contact := &models.Contact{
+		ID:           uuid.New().String(),
+		TenantID:     tenantID,
+		Name:         name,
+		Email:        email,
+		FirstMet:     &eventStart,
+		LastMet:      &eventStart,
+		MeetingCount: 1,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := s.repos.Contact.Upsert(ctx, contact); err != nil {
+		log.Printf("[CONTACT] Error upserting contact for %s: %v", email, err)
+	}
+}
+
 // BackfillFromBookings creates/updates contacts from all confirmed bookings for a tenant.
 func (s *ContactService) BackfillFromBookings(ctx context.Context, tenantID string) (int, error) {
 	bookings, err := s.repos.Booking.ListConfirmedByTenant(ctx, tenantID)
@@ -146,4 +172,3 @@ func (s *ContactService) EnsureBackfilled(ctx context.Context, tenantID string) 
 	}
 	return nil
 }
-

--- a/internal/services/email.go
+++ b/internal/services/email.go
@@ -914,6 +914,327 @@ func formatCancelReason(reason string) string {
 	return fmt.Sprintf("Reason: %s", reason)
 }
 
+// hostedEventTime returns the start time formatted in the event's timezone
+// (which is the host's perspective at scheduling time). Hosted-event attendees
+// don't carry a per-attendee tz today, so this is the best display choice.
+func hostedEventTime(event *models.HostedEvent) string {
+	loc, err := time.LoadLocation(event.Timezone)
+	if err != nil || loc == nil {
+		loc = time.UTC
+	}
+	return event.StartTime.In(loc).Format("Monday, January 2, 2006 at 3:04 PM MST")
+}
+
+// hostedEventLocationLabel returns the human-readable location for an event
+// (mirrors the per-LocationType branching in booking emails).
+func hostedEventLocationLabel(event *models.HostedEvent) string {
+	switch event.LocationType {
+	case models.ConferencingProviderPhone:
+		if event.CustomLocation != "" {
+			return "Call " + event.CustomLocation
+		}
+	case models.ConferencingProviderCustom:
+		if event.CustomLocation != "" {
+			return event.CustomLocation
+		}
+	}
+	if event.ConferenceLink != "" {
+		return event.ConferenceLink
+	}
+	if event.CustomLocation != "" {
+		return event.CustomLocation
+	}
+	return "To be determined"
+}
+
+// SendHostedEventInvited sends an invitation to a single attendee. Used both
+// at create time (every attendee) and on update when an attendee is added.
+func (s *EmailService) SendHostedEventInvited(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("%s invited you: %s", host.Name, event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	descriptionBlock := ""
+	if event.Description != "" {
+		descriptionBlock = fmt.Sprintf("\n%s\n", event.Description)
+	}
+
+	body := fmt.Sprintf(`%s,
+
+%s has scheduled a meeting with you:
+
+Meeting: %s
+When: %s
+Duration: %d minutes
+Location: %s
+%s
+This event has been added to your calendar. RSVP via your calendar app.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+		event.Duration,
+		hostedEventLocationLabel(event),
+		descriptionBlock,
+	)
+
+	ics := s.generateICSForHostedEvent(event, host, attendee, "REQUEST", "CONFIRMED")
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ics); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event invitation to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	// Notify the host as well, but only for create-time invitations the host
+	// will have a list of all attendees in their calendar — skip a per-host
+	// duplicate to avoid noise. (Mirrors booking flow which sends one host
+	// email per booking, not per guest.)
+	_ = tenant
+}
+
+// SendHostedEventUpdated notifies a retained attendee that material event
+// fields changed (time, title, location, etc.).
+func (s *EmailService) SendHostedEventUpdated(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant, changedFields []string) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("Updated: %s", event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	changedSummary := ""
+	if len(changedFields) > 0 {
+		changedSummary = fmt.Sprintf("\nWhat changed: %s\n", strings.Join(changedFields, ", "))
+	}
+
+	body := fmt.Sprintf(`%s,
+
+%s updated a meeting with you:
+
+Meeting: %s
+When: %s
+Duration: %d minutes
+Location: %s
+%s
+Your calendar has been updated automatically.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+		event.Duration,
+		hostedEventLocationLabel(event),
+		changedSummary,
+	)
+
+	ics := s.generateICSForHostedEvent(event, host, attendee, "REQUEST", "CONFIRMED")
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ics); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event update to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	_ = tenant
+}
+
+// SendHostedEventCancelled notifies an attendee that the entire event was
+// cancelled. The ICS is METHOD:CANCEL so calendar clients can remove it.
+func (s *EmailService) SendHostedEventCancelled(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("Cancelled: %s", event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	body := fmt.Sprintf(`%s,
+
+%s has cancelled this meeting:
+
+Meeting: %s
+Was scheduled for: %s
+
+%s
+
+The event has been removed from your calendar.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+		formatCancelReason(event.CancelReason),
+	)
+
+	ics := s.generateICSForHostedEvent(event, host, attendee, "CANCEL", "CANCELLED")
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ics); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event cancellation to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	_ = tenant
+}
+
+// SendHostedEventCancelledForAttendee notifies an attendee that they were
+// removed from an event that otherwise still goes ahead.
+func (s *EmailService) SendHostedEventCancelledForAttendee(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("You were removed from: %s", event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	body := fmt.Sprintf(`%s,
+
+%s has removed you from this meeting:
+
+Meeting: %s
+Was scheduled for: %s
+
+The event has been removed from your calendar.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+	)
+
+	// CANCEL ICS scoped to this attendee — removes only their copy.
+	ics := s.generateICSForHostedEvent(event, host, attendee, "CANCEL", "CANCELLED")
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ics); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event removal to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	_ = tenant
+}
+
+// SendHostedEventReminder sends a 24-hour reminder to a single attendee.
+func (s *EmailService) SendHostedEventReminder(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant) {
+	if attendee == nil || attendee.Email == "" {
+		return
+	}
+	subject := fmt.Sprintf("Reminder: %s tomorrow", event.Title)
+
+	greeting := "Hello"
+	if attendee.Name != "" {
+		greeting = "Hello " + attendee.Name
+	}
+
+	body := fmt.Sprintf(`%s,
+
+This is a reminder of your upcoming meeting with %s:
+
+Meeting: %s
+When: %s
+Duration: %d minutes
+Location: %s
+
+See you tomorrow.
+
+Best regards,
+Meet When`,
+		greeting,
+		host.Name,
+		event.Title,
+		hostedEventTime(event),
+		event.Duration,
+		hostedEventLocationLabel(event),
+	)
+
+	go func() {
+		if err := s.sendEmail(attendee.Email, subject, body, ""); err != nil {
+			log.Printf("[EMAIL] Error sending hosted-event reminder to %s: %v", attendee.Email, err)
+		}
+	}()
+
+	_ = tenant
+}
+
+// generateICSForHostedEvent emits an ICS payload for a hosted event addressed
+// to a single attendee. method is "REQUEST" for invites/updates or "CANCEL"
+// for cancellations; status is "CONFIRMED" or "CANCELLED" accordingly.
+func (s *EmailService) generateICSForHostedEvent(event *models.HostedEvent, host *models.Host, attendee *models.HostedEventAttendee, method, status string) string {
+	location := ""
+	switch event.LocationType {
+	case models.ConferencingProviderPhone:
+		if event.CustomLocation != "" {
+			location = "Call " + event.CustomLocation
+		}
+	default:
+		if event.ConferenceLink != "" {
+			location = event.ConferenceLink
+		} else if event.CustomLocation != "" {
+			location = event.CustomLocation
+		}
+	}
+
+	attendeeName := attendee.Name
+	if attendeeName == "" {
+		attendeeName = attendee.Email
+	}
+
+	return fmt.Sprintf(`BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//MeetWhen//EN
+METHOD:%s
+BEGIN:VEVENT
+UID:%s@meetwhen
+DTSTART:%s
+DTEND:%s
+SUMMARY:%s
+DESCRIPTION:%s
+LOCATION:%s
+ORGANIZER;CN=%s:mailto:%s
+ATTENDEE;CN=%s:mailto:%s
+STATUS:%s
+END:VEVENT
+END:VCALENDAR`,
+		method,
+		event.ID,
+		event.StartTime.UTC().Format("20060102T150405Z"),
+		event.EndTime.UTC().Format("20060102T150405Z"),
+		escapeICS(event.Title),
+		escapeICS(event.Description),
+		escapeICS(location),
+		host.Name,
+		host.Email,
+		attendeeName,
+		attendee.Email,
+		status,
+	)
+}
+
 func escapeICS(s string) string {
 	s = strings.ReplaceAll(s, "\\", "\\\\")
 	s = strings.ReplaceAll(s, ";", "\\;")

--- a/internal/services/hosted_event.go
+++ b/internal/services/hosted_event.go
@@ -1,0 +1,861 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/config"
+	"github.com/meet-when/meet-when/internal/models"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// AttendeeInput is the host-supplied attendee shape used by Create / Update
+// inputs. ContactID is non-nil when the attendee was picked from the contact
+// list, nil for free-form entries.
+type AttendeeInput struct {
+	Email     string
+	Name      string
+	ContactID *string
+}
+
+// CreateHostedEventInput is the host-supplied data needed to schedule a new
+// hosted event. Times are passed as time.Time and converted to SQLiteTime
+// internally.
+type CreateHostedEventInput struct {
+	HostID         string
+	TenantID       string
+	TemplateID     *string
+	Title          string
+	Description    string
+	Start          time.Time
+	Duration       int // minutes
+	Timezone       string
+	LocationType   models.ConferencingProvider
+	CustomLocation string
+	CalendarID     string
+	Attendees      []AttendeeInput
+}
+
+// UpdateHostedEventInput uses pointer fields for "change if non-nil"
+// semantics so the caller can express partial updates without ambiguity
+// between "no change" and "set to zero value".
+type UpdateHostedEventInput struct {
+	HostID                   string
+	TenantID                 string
+	EventID                  string
+	Title                    *string
+	Description              *string
+	CustomLocation           *string
+	Start                    *time.Time
+	Duration                 *int
+	Timezone                 *string
+	LocationType             *models.ConferencingProvider
+	CalendarID               *string
+	Attendees                *[]AttendeeInput
+	RegenerateConferenceLink bool
+}
+
+// HostedEventWithDetails bundles a hosted event with the joined entities
+// callers usually need (host, tenant, optional template, attendees).
+type HostedEventWithDetails struct {
+	Event     *models.HostedEvent
+	Host      *models.Host
+	Tenant    *models.Tenant
+	Template  *models.MeetingTemplate
+	Attendees []*models.HostedEventAttendee
+}
+
+// hostedEventEmailSender is the narrow surface HostedEventService needs from
+// the email layer. *EmailService satisfies it; tests inject a spy.
+type hostedEventEmailSender interface {
+	SendHostedEventInvited(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant)
+	SendHostedEventUpdated(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant, changedFields []string)
+	SendHostedEventCancelled(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant)
+	SendHostedEventCancelledForAttendee(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant)
+	SendHostedEventReminder(ctx context.Context, event *models.HostedEvent, attendee *models.HostedEventAttendee, host *models.Host, tenant *models.Tenant)
+}
+
+// HostedEventService orchestrates host-driven event scheduling. The shared
+// per-host calendar fan-out lives in CalendarEventSyncer (PR #43); this
+// service owns the entity-specific orchestration (validation, conferencing,
+// attendee diff, contact upsert, audit, email).
+type HostedEventService struct {
+	cfg          *config.Config
+	repos        *repository.Repositories
+	calendar     *CalendarService
+	conferencing *ConferencingService
+	syncer       *CalendarEventSyncer
+	email        hostedEventEmailSender
+	contact      *ContactService
+	audit        *AuditLogService
+}
+
+// NewHostedEventService constructs a HostedEventService.
+func NewHostedEventService(
+	cfg *config.Config,
+	repos *repository.Repositories,
+	calendar *CalendarService,
+	conferencing *ConferencingService,
+	syncer *CalendarEventSyncer,
+	email hostedEventEmailSender,
+	contact *ContactService,
+	audit *AuditLogService,
+) *HostedEventService {
+	return &HostedEventService{
+		cfg:          cfg,
+		repos:        repos,
+		calendar:     calendar,
+		conferencing: conferencing,
+		syncer:       syncer,
+		email:        email,
+		contact:      contact,
+		audit:        audit,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Read paths
+// ---------------------------------------------------------------------------
+
+// Get returns a hosted event with its joined details, scoped to the caller.
+// Returns (nil, nil) when not found; (nil, error) when the lookup itself
+// fails. Returns an error when the host/tenant scope mismatches.
+func (s *HostedEventService) Get(ctx context.Context, hostID, tenantID, eventID string) (*HostedEventWithDetails, error) {
+	event, err := s.repos.HostedEvent.GetByID(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+	if event == nil {
+		return nil, nil
+	}
+	if event.HostID != hostID || event.TenantID != tenantID {
+		return nil, errors.New("hosted event not found")
+	}
+	return s.loadDetails(ctx, event)
+}
+
+// List returns the host's hosted events ordered by start_time descending.
+func (s *HostedEventService) List(ctx context.Context, hostID string, includeArchived bool) ([]*models.HostedEvent, error) {
+	return s.repos.HostedEvent.ListByHost(ctx, hostID, includeArchived)
+}
+
+func (s *HostedEventService) loadDetails(ctx context.Context, event *models.HostedEvent) (*HostedEventWithDetails, error) {
+	host, err := s.repos.Host.GetByID(ctx, event.HostID)
+	if err != nil {
+		return nil, fmt.Errorf("load host: %w", err)
+	}
+	tenant, err := s.repos.Tenant.GetByID(ctx, event.TenantID)
+	if err != nil {
+		return nil, fmt.Errorf("load tenant: %w", err)
+	}
+	var template *models.MeetingTemplate
+	if event.TemplateID != nil && *event.TemplateID != "" {
+		template, _ = s.repos.Template.GetByID(ctx, *event.TemplateID) // best-effort
+	}
+	attendees, err := s.repos.HostedEventAttendee.ListByEvent(ctx, event.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load attendees: %w", err)
+	}
+	return &HostedEventWithDetails{
+		Event:     event,
+		Host:      host,
+		Tenant:    tenant,
+		Template:  template,
+		Attendees: attendees,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+// Create schedules a new hosted event:
+//  1. validates input
+//  2. resolves the calendar to write to
+//  3. persists the event + attendees in a tx
+//  4. creates a conferencing link if needed (best-effort; reauth-required
+//     surfaces but doesn't abort)
+//  5. fans out the calendar event via the syncer; the calendar layer may
+//     surface a conference link of its own (Google Meet) which is then
+//     persisted with a second write
+//  6. notifies attendees via email
+//  7. upserts contact rows for each attendee
+//  8. writes an audit entry
+func (s *HostedEventService) Create(ctx context.Context, input CreateHostedEventInput) (*HostedEventWithDetails, error) {
+	if err := s.validateCreate(input); err != nil {
+		return nil, err
+	}
+
+	host, err := s.repos.Host.GetByID(ctx, input.HostID)
+	if err != nil {
+		return nil, fmt.Errorf("load host: %w", err)
+	}
+	if host == nil || host.TenantID != input.TenantID {
+		return nil, errors.New("host not found")
+	}
+	tenant, err := s.repos.Tenant.GetByID(ctx, input.TenantID)
+	if err != nil || tenant == nil {
+		return nil, fmt.Errorf("load tenant: %w", err)
+	}
+
+	calendarID, err := s.resolveCalendarID(ctx, host, input.TemplateID, input.CalendarID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := models.Now()
+	end := input.Start.Add(time.Duration(input.Duration) * time.Minute)
+	tz := input.Timezone
+	if tz == "" {
+		tz = host.Timezone
+	}
+
+	event := &models.HostedEvent{
+		ID:             uuid.New().String(),
+		TenantID:       input.TenantID,
+		HostID:         input.HostID,
+		TemplateID:     input.TemplateID,
+		Title:          input.Title,
+		Description:    input.Description,
+		StartTime:      models.NewSQLiteTime(input.Start),
+		EndTime:        models.NewSQLiteTime(end),
+		Duration:       input.Duration,
+		Timezone:       tz,
+		LocationType:   input.LocationType,
+		CustomLocation: input.CustomLocation,
+		CalendarID:     calendarID,
+		Status:         models.HostedEventStatusScheduled,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	if err := s.repos.HostedEvent.Create(ctx, event); err != nil {
+		return nil, fmt.Errorf("persist event: %w", err)
+	}
+
+	attendees := s.buildAttendeeRows(event.ID, input.Attendees, now)
+	if err := s.repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, attendees); err != nil {
+		return nil, fmt.Errorf("persist attendees: %w", err)
+	}
+
+	// Conferencing — best-effort. ErrConferencingReauthRequired is logged
+	// but does not abort the event creation: the calendar event still goes
+	// out and the host can fix the conferencing link via retry.
+	if event.LocationType == models.ConferencingProviderZoom ||
+		event.LocationType == models.ConferencingProviderGoogleMeet ||
+		event.LocationType == models.ConferencingProviderPhone ||
+		event.LocationType == models.ConferencingProviderCustom {
+		link, err := s.conferencing.CreateMeetingForHostedEvent(ctx, host.ID, event.Title, event.StartTime.Time, event.Duration, event.LocationType, event.CustomLocation)
+		if err != nil {
+			if errors.Is(err, ErrConferencingReauthRequired) {
+				log.Printf("[HOSTED_EVENT] Conferencing reauth required for host %s on event %s; event will be created without a link", host.ID, event.ID)
+			} else {
+				log.Printf("[HOSTED_EVENT] Conferencing error for event %s: %v", event.ID, err)
+			}
+		} else if link != "" {
+			event.ConferenceLink = link
+		}
+	}
+
+	// Persist the conferencing-link write before fan-out so the calendar
+	// event carries the same link.
+	if event.ConferenceLink != "" {
+		event.UpdatedAt = models.Now()
+		if err := s.repos.HostedEvent.Update(ctx, event); err != nil {
+			log.Printf("[HOSTED_EVENT] Error persisting conference link on event %s: %v", event.ID, err)
+		}
+	}
+
+	// Calendar fan-out via the shared syncer. v1 hosted events have no
+	// pooled hosts — just the owner.
+	syncInput := s.buildCalendarEventInput(event, attendees, host, "" /* eventID empty for create */)
+	firstID, syncerLink, err := s.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindHostedEvent,
+		ItemID: event.ID,
+		Input:  syncInput,
+		Hosts:  []HostTarget{{HostID: host.ID, CalendarID: calendarID, IsOwner: true}},
+	})
+	if err != nil {
+		log.Printf("[HOSTED_EVENT] Syncer.Create error for event %s: %v", event.ID, err)
+	}
+	// Google Meet returns the link from the calendar create response; persist
+	// it (and the first event ID) — second write.
+	persistChanged := false
+	if syncerLink != "" && event.ConferenceLink == "" {
+		event.ConferenceLink = syncerLink
+		persistChanged = true
+	}
+	if persistChanged {
+		event.UpdatedAt = models.Now()
+		if err := s.repos.HostedEvent.Update(ctx, event); err != nil {
+			log.Printf("[HOSTED_EVENT] Error persisting post-sync link on event %s: %v", event.ID, err)
+		}
+	}
+	_ = firstID // tracked in hosted_event_calendar_events; not needed on the event row for v1
+
+	// Email each attendee.
+	for _, a := range attendees {
+		s.email.SendHostedEventInvited(ctx, event, a, host, tenant)
+	}
+
+	// Contact upsert for every attendee at create time (each attendee is
+	// "new" in the sense that this event is the first occurrence with them).
+	for _, a := range attendees {
+		s.contact.UpsertFromHostedEventAttendee(ctx, event.TenantID, a.Email, a.Name, event.StartTime)
+	}
+
+	hostID := host.ID
+	s.audit.Log(ctx, event.TenantID, &hostID, "hosted_event.created", "hosted_event", event.ID, models.JSONMap{
+		"title":     event.Title,
+		"start":     event.StartTime.UTC().Format(time.RFC3339),
+		"duration":  event.Duration,
+		"attendees": attendeeEmails(attendees),
+	}, "")
+
+	return &HostedEventWithDetails{
+		Event:     event,
+		Host:      host,
+		Tenant:    tenant,
+		Attendees: attendees,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+// Update applies a partial change to an existing event. Pointer fields on
+// UpdateHostedEventInput follow "change if non-nil" semantics. Returns the
+// updated details and the list of changed field names (for the audit entry
+// and email content).
+//
+// Behavioural notes:
+//   - When Start changes, reminder_sent is reset so the reminder loop fires
+//     against the new time.
+//   - Conferencing is regenerated only if RegenerateConferenceLink is set or
+//     LocationType changes — same shape as the booking flow.
+//   - Attendee diff is computed on lowercased email; added attendees get an
+//     "invited" email, removed get "cancelled-for-attendee", retained get
+//     an "updated" email iff a material field changed.
+//   - Contact upsert fires only for newly added attendees, so meeting_count
+//     and last_met don't get re-incremented on a benign edit.
+func (s *HostedEventService) Update(ctx context.Context, input UpdateHostedEventInput) (*HostedEventWithDetails, []string, error) {
+	if input.HostID == "" || input.TenantID == "" || input.EventID == "" {
+		return nil, nil, errors.New("host, tenant, and event ID are required")
+	}
+
+	details, err := s.Get(ctx, input.HostID, input.TenantID, input.EventID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if details == nil {
+		return nil, nil, errors.New("hosted event not found")
+	}
+	if details.Event.Status == models.HostedEventStatusCancelled {
+		return nil, nil, errors.New("cannot update a cancelled event")
+	}
+
+	event := details.Event
+	previousStart := event.StartTime
+	prevAttendees := details.Attendees
+
+	// ---- Field diff ----
+	changed := []string{}
+
+	if input.Title != nil && *input.Title != event.Title {
+		if strings.TrimSpace(*input.Title) == "" {
+			return nil, nil, errors.New("title cannot be empty")
+		}
+		event.Title = *input.Title
+		changed = append(changed, "title")
+	}
+	if input.Description != nil && *input.Description != event.Description {
+		event.Description = *input.Description
+		changed = append(changed, "description")
+	}
+	if input.CustomLocation != nil && *input.CustomLocation != event.CustomLocation {
+		event.CustomLocation = *input.CustomLocation
+		changed = append(changed, "custom_location")
+	}
+	if input.LocationType != nil && *input.LocationType != event.LocationType {
+		event.LocationType = *input.LocationType
+		changed = append(changed, "location_type")
+	}
+	if input.Timezone != nil && *input.Timezone != event.Timezone {
+		event.Timezone = *input.Timezone
+		changed = append(changed, "timezone")
+	}
+	if input.CalendarID != nil && *input.CalendarID != event.CalendarID {
+		event.CalendarID = *input.CalendarID
+		changed = append(changed, "calendar_id")
+	}
+
+	// Start / Duration changes ripple into EndTime.
+	startChanged := false
+	durationChanged := false
+	if input.Duration != nil && *input.Duration > 0 && *input.Duration != event.Duration {
+		event.Duration = *input.Duration
+		changed = append(changed, "duration")
+		durationChanged = true
+	}
+	if input.Start != nil && !input.Start.Equal(event.StartTime.Time) {
+		event.StartTime = models.NewSQLiteTime(*input.Start)
+		changed = append(changed, "start")
+		startChanged = true
+	}
+	if startChanged || durationChanged {
+		event.EndTime = models.NewSQLiteTime(event.StartTime.Time.Add(time.Duration(event.Duration) * time.Minute))
+	}
+
+	// ---- Attendee diff ----
+	addedAttendeeRows := []*models.HostedEventAttendee{}
+	removedAttendees := []*models.HostedEventAttendee{}
+	retainedAttendees := []*models.HostedEventAttendee{}
+	finalAttendees := prevAttendees
+
+	if input.Attendees != nil {
+		now := models.Now()
+		incoming := s.buildAttendeeRows(event.ID, *input.Attendees, now)
+		if len(incoming) == 0 {
+			return nil, nil, errors.New("at least one attendee is required")
+		}
+
+		prevByEmail := indexAttendeesByEmail(prevAttendees)
+		incomingByEmail := indexAttendeesByEmail(incoming)
+
+		for email, row := range incomingByEmail {
+			if existing, ok := prevByEmail[email]; ok {
+				// Retain — but inherit the prior row's ID and CreatedAt so the
+				// attendee history is preserved when ReplaceForEvent re-inserts.
+				row.ID = existing.ID
+				row.CreatedAt = existing.CreatedAt
+				retainedAttendees = append(retainedAttendees, row)
+			} else {
+				addedAttendeeRows = append(addedAttendeeRows, row)
+			}
+		}
+		for email, row := range prevByEmail {
+			if _, ok := incomingByEmail[email]; !ok {
+				removedAttendees = append(removedAttendees, row)
+			}
+		}
+
+		// Sort for deterministic order downstream (emails, audit detail).
+		sort.Slice(retainedAttendees, func(i, j int) bool { return retainedAttendees[i].Email < retainedAttendees[j].Email })
+		sort.Slice(addedAttendeeRows, func(i, j int) bool { return addedAttendeeRows[i].Email < addedAttendeeRows[j].Email })
+		sort.Slice(removedAttendees, func(i, j int) bool { return removedAttendees[i].Email < removedAttendees[j].Email })
+
+		finalAttendees = make([]*models.HostedEventAttendee, 0, len(retainedAttendees)+len(addedAttendeeRows))
+		finalAttendees = append(finalAttendees, retainedAttendees...)
+		finalAttendees = append(finalAttendees, addedAttendeeRows...)
+
+		if len(addedAttendeeRows) > 0 || len(removedAttendees) > 0 {
+			changed = append(changed, "attendees")
+		}
+	}
+
+	// Nothing changed — fast exit.
+	if len(changed) == 0 && !input.RegenerateConferenceLink {
+		return details, nil, nil
+	}
+
+	// ---- Conferencing regeneration ----
+	conferencingChanged := false
+	if input.RegenerateConferenceLink || sliceContains(changed, "location_type") {
+		link, err := s.conferencing.CreateMeetingForHostedEvent(ctx, details.Host.ID, event.Title, event.StartTime.Time, event.Duration, event.LocationType, event.CustomLocation)
+		if err != nil {
+			if errors.Is(err, ErrConferencingReauthRequired) {
+				return nil, nil, ErrConferencingReauthRequired
+			}
+			log.Printf("[HOSTED_EVENT] Conferencing error during update of event %s: %v", event.ID, err)
+		} else if link != event.ConferenceLink {
+			event.ConferenceLink = link
+			conferencingChanged = true
+		}
+	}
+	if conferencingChanged && !sliceContains(changed, "conference_link") {
+		changed = append(changed, "conference_link")
+	}
+
+	// ---- reminder_sent reset on time change ----
+	if startChanged && event.ReminderSent {
+		event.ReminderSent = false
+	}
+
+	// ---- Persist event + attendees ----
+	event.UpdatedAt = models.Now()
+	if err := s.repos.HostedEvent.Update(ctx, event); err != nil {
+		return nil, nil, fmt.Errorf("persist event update: %w", err)
+	}
+	if input.Attendees != nil {
+		if err := s.repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, finalAttendees); err != nil {
+			return nil, nil, fmt.Errorf("persist attendee update: %w", err)
+		}
+	}
+
+	// ---- Calendar fan-out (Update across all tracked rows) ----
+	syncInput := s.buildCalendarEventInput(event, finalAttendees, details.Host, "" /* per-row EventID is filled by syncer */)
+	if err := s.syncer.Update(ctx, CalendarSyncRequest{
+		Kind:   ItemKindHostedEvent,
+		ItemID: event.ID,
+		Input:  syncInput,
+		Hosts:  []HostTarget{{HostID: details.Host.ID, CalendarID: event.CalendarID, IsOwner: true}},
+	}); err != nil {
+		log.Printf("[HOSTED_EVENT] Syncer.Update error for event %s: %v", event.ID, err)
+	}
+
+	// ---- Email fan-out ----
+	materialChanged := hasMaterialChange(changed)
+	for _, a := range removedAttendees {
+		s.email.SendHostedEventCancelledForAttendee(ctx, event, a, details.Host, details.Tenant)
+	}
+	for _, a := range addedAttendeeRows {
+		s.email.SendHostedEventInvited(ctx, event, a, details.Host, details.Tenant)
+	}
+	if materialChanged {
+		for _, a := range retainedAttendees {
+			s.email.SendHostedEventUpdated(ctx, event, a, details.Host, details.Tenant, changed)
+		}
+	}
+
+	// ---- Contact upsert (added attendees only) ----
+	for _, a := range addedAttendeeRows {
+		s.contact.UpsertFromHostedEventAttendee(ctx, event.TenantID, a.Email, a.Name, event.StartTime)
+	}
+
+	// ---- Audit ----
+	hID := input.HostID
+	auditDetails := models.JSONMap{
+		"changed_fields": changed,
+	}
+	if startChanged {
+		auditDetails["previous_start"] = previousStart.UTC().Format(time.RFC3339)
+		auditDetails["new_start"] = event.StartTime.UTC().Format(time.RFC3339)
+	}
+	if len(addedAttendeeRows) > 0 {
+		auditDetails["added_attendees"] = attendeeEmails(addedAttendeeRows)
+	}
+	if len(removedAttendees) > 0 {
+		auditDetails["removed_attendees"] = attendeeEmails(removedAttendees)
+	}
+	s.audit.Log(ctx, event.TenantID, &hID, "hosted_event.updated", "hosted_event", event.ID, auditDetails, "")
+
+	out := &HostedEventWithDetails{
+		Event:     event,
+		Host:      details.Host,
+		Tenant:    details.Tenant,
+		Template:  details.Template,
+		Attendees: finalAttendees,
+	}
+	return out, changed, nil
+}
+
+// indexAttendeesByEmail returns a lowercase-email-keyed index of attendee
+// rows. Inputs from buildAttendeeRows are already lowercased; this is mostly
+// a defensive convenience for the existing-rows side.
+func indexAttendeesByEmail(rows []*models.HostedEventAttendee) map[string]*models.HostedEventAttendee {
+	out := make(map[string]*models.HostedEventAttendee, len(rows))
+	for _, r := range rows {
+		out[strings.ToLower(r.Email)] = r
+	}
+	return out
+}
+
+// hasMaterialChange returns true when any of the changed fields warrants
+// emailing retained attendees. "Calendar ID" alone is internal plumbing —
+// it doesn't change what the attendee sees.
+func hasMaterialChange(changed []string) bool {
+	for _, f := range changed {
+		switch f {
+		case "title", "description", "start", "duration", "location_type",
+			"custom_location", "conference_link", "timezone", "attendees":
+			return true
+		}
+	}
+	return false
+}
+
+func sliceContains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Cancel
+// ---------------------------------------------------------------------------
+
+// Cancel marks the event cancelled, removes it from every tracked host
+// calendar, emails attendees, and writes an audit entry.
+func (s *HostedEventService) Cancel(ctx context.Context, hostID, tenantID, eventID, reason string) error {
+	details, err := s.Get(ctx, hostID, tenantID, eventID)
+	if err != nil {
+		return err
+	}
+	if details == nil {
+		return errors.New("hosted event not found")
+	}
+	if details.Event.Status == models.HostedEventStatusCancelled {
+		return nil
+	}
+
+	details.Event.Status = models.HostedEventStatusCancelled
+	details.Event.CancelReason = reason
+	details.Event.UpdatedAt = models.Now()
+	if err := s.repos.HostedEvent.Update(ctx, details.Event); err != nil {
+		return fmt.Errorf("persist cancel: %w", err)
+	}
+
+	if _, err := s.syncer.Delete(ctx, ItemKindHostedEvent, eventID); err != nil {
+		log.Printf("[HOSTED_EVENT] Syncer.Delete error for event %s: %v", eventID, err)
+	}
+
+	for _, a := range details.Attendees {
+		s.email.SendHostedEventCancelled(ctx, details.Event, a, details.Host, details.Tenant)
+	}
+
+	hID := hostID
+	s.audit.Log(ctx, tenantID, &hID, "hosted_event.cancelled", "hosted_event", eventID, models.JSONMap{
+		"reason": reason,
+	}, "")
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Archive / Unarchive / Retry
+// ---------------------------------------------------------------------------
+
+// Archive marks the event archived (removes it from the default list view
+// without affecting calendar state).
+func (s *HostedEventService) Archive(ctx context.Context, hostID, tenantID, eventID string) error {
+	return s.toggleArchive(ctx, hostID, tenantID, eventID, true, "hosted_event.archived")
+}
+
+// Unarchive reverses Archive.
+func (s *HostedEventService) Unarchive(ctx context.Context, hostID, tenantID, eventID string) error {
+	return s.toggleArchive(ctx, hostID, tenantID, eventID, false, "hosted_event.unarchived")
+}
+
+func (s *HostedEventService) toggleArchive(ctx context.Context, hostID, tenantID, eventID string, archived bool, action string) error {
+	event, err := s.repos.HostedEvent.GetByID(ctx, eventID)
+	if err != nil {
+		return err
+	}
+	if event == nil || event.HostID != hostID || event.TenantID != tenantID {
+		return errors.New("hosted event not found")
+	}
+	if event.IsArchived == archived {
+		return nil
+	}
+	event.IsArchived = archived
+	event.UpdatedAt = models.Now()
+	if err := s.repos.HostedEvent.Update(ctx, event); err != nil {
+		return err
+	}
+	hID := hostID
+	s.audit.Log(ctx, tenantID, &hID, action, "hosted_event", eventID, nil, "")
+	return nil
+}
+
+// RetryCalendarEvent re-creates the calendar event for an event that has no
+// tracking rows (i.e. the original creation failed). Useful when the host
+// reconnects a calendar after the event was scheduled.
+func (s *HostedEventService) RetryCalendarEvent(ctx context.Context, hostID, tenantID, eventID string) error {
+	details, err := s.Get(ctx, hostID, tenantID, eventID)
+	if err != nil {
+		return err
+	}
+	if details == nil {
+		return errors.New("hosted event not found")
+	}
+	if details.Event.Status != models.HostedEventStatusScheduled {
+		return errors.New("only scheduled events can have calendar events retried")
+	}
+
+	syncInput := s.buildCalendarEventInput(details.Event, details.Attendees, details.Host, "")
+	if _, _, err := s.syncer.Create(ctx, CalendarSyncRequest{
+		Kind:   ItemKindHostedEvent,
+		ItemID: details.Event.ID,
+		Input:  syncInput,
+		Hosts:  []HostTarget{{HostID: details.Host.ID, CalendarID: details.Event.CalendarID, IsOwner: true}},
+	}); err != nil {
+		return fmt.Errorf("syncer create: %w", err)
+	}
+
+	hID := hostID
+	s.audit.Log(ctx, tenantID, &hID, "hosted_event.calendar_retried", "hosted_event", eventID, nil, "")
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Conflict detection
+// ---------------------------------------------------------------------------
+
+// DetectBusyConflicts merges three sources to surface scheduling conflicts:
+// provider busy times, the host's confirmed bookings, and other hosted events.
+// excludeEventID skips an event from the hosted-events lookup so editing an
+// existing event doesn't report itself. Returns the overlapping windows; the
+// caller decides whether to warn or block (host-driven scheduling never
+// blocks — soft warning only).
+func (s *HostedEventService) DetectBusyConflicts(ctx context.Context, hostID string, start, end time.Time, excludeEventID string) ([]models.TimeSlot, error) {
+	var conflicts []models.TimeSlot
+
+	// Source 1: provider busy times.
+	busy, err := s.calendar.GetBusyTimes(ctx, hostID, start, end)
+	if err == nil {
+		for _, b := range busy {
+			if b.Start.Before(end) && b.End.After(start) {
+				conflicts = append(conflicts, b)
+			}
+		}
+	}
+
+	// Source 2: confirmed bookings in the window.
+	bookings, err := s.repos.Booking.GetByHostIDAndTimeRange(ctx, hostID, start, end)
+	if err == nil {
+		for _, b := range bookings {
+			if b.Status != models.BookingStatusConfirmed {
+				continue
+			}
+			conflicts = append(conflicts, models.TimeSlot{
+				Start: b.StartTime.Time,
+				End:   b.EndTime.Time,
+			})
+		}
+	}
+
+	// Source 3: other hosted events (scheduled status only; excluding self).
+	var exclude *string
+	if excludeEventID != "" {
+		exclude = &excludeEventID
+	}
+	others, err := s.repos.HostedEvent.GetByHostIDAndTimeRange(ctx, hostID, start, end, exclude)
+	if err == nil {
+		for _, o := range others {
+			conflicts = append(conflicts, models.TimeSlot{
+				Start: o.StartTime.Time,
+				End:   o.EndTime.Time,
+			})
+		}
+	}
+
+	// Sort for stable output.
+	sort.Slice(conflicts, func(i, j int) bool {
+		return conflicts[i].Start.Before(conflicts[j].Start)
+	})
+
+	return conflicts, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func (s *HostedEventService) validateCreate(input CreateHostedEventInput) error {
+	if strings.TrimSpace(input.Title) == "" {
+		return errors.New("title is required")
+	}
+	if input.Duration <= 0 {
+		return errors.New("duration must be positive")
+	}
+	if input.HostID == "" || input.TenantID == "" {
+		return errors.New("host and tenant are required")
+	}
+	if len(input.Attendees) == 0 {
+		return errors.New("at least one attendee is required")
+	}
+	for _, a := range input.Attendees {
+		if !isValidEmail(a.Email) {
+			return fmt.Errorf("invalid attendee email: %s", a.Email)
+		}
+	}
+	return nil
+}
+
+// resolveCalendarID picks the calendar to write to: explicit input → template
+// default → host default. Falls back to "" so the syncer's
+// resolveWritableCalendarID can pick the first writable provider calendar.
+func (s *HostedEventService) resolveCalendarID(ctx context.Context, host *models.Host, templateID *string, explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if templateID != nil && *templateID != "" {
+		template, err := s.repos.Template.GetByID(ctx, *templateID)
+		if err == nil && template != nil && template.CalendarID != "" {
+			return template.CalendarID, nil
+		}
+	}
+	if host.DefaultCalendarID != nil && *host.DefaultCalendarID != "" {
+		return *host.DefaultCalendarID, nil
+	}
+	return "", nil
+}
+
+// buildAttendeeRows converts AttendeeInputs into HostedEventAttendee rows.
+// Emails are lower-cased and de-duplicated (case-insensitive) so the unique
+// constraint on (hosted_event_id, email) is never tripped by minor user
+// inconsistencies.
+func (s *HostedEventService) buildAttendeeRows(eventID string, inputs []AttendeeInput, now models.SQLiteTime) []*models.HostedEventAttendee {
+	seen := make(map[string]bool, len(inputs))
+	out := make([]*models.HostedEventAttendee, 0, len(inputs))
+	for _, in := range inputs {
+		email := strings.ToLower(strings.TrimSpace(in.Email))
+		if email == "" || seen[email] {
+			continue
+		}
+		seen[email] = true
+		out = append(out, &models.HostedEventAttendee{
+			ID:            uuid.New().String(),
+			HostedEventID: eventID,
+			Email:         email,
+			Name:          strings.TrimSpace(in.Name),
+			ContactID:     in.ContactID,
+			CreatedAt:     now,
+		})
+	}
+	return out
+}
+
+// buildCalendarEventInput composes the provider-agnostic input the syncer
+// hands to the calendar layer. existingEventID is set on update flows so the
+// calendar provider patches in place; empty for create.
+func (s *HostedEventService) buildCalendarEventInput(event *models.HostedEvent, attendees []*models.HostedEventAttendee, host *models.Host, existingEventID string) CalendarEventInput {
+	emails := make([]string, 0, len(attendees))
+	for _, a := range attendees {
+		if a.Email != "" {
+			emails = append(emails, a.Email)
+		}
+	}
+	return CalendarEventInput{
+		Summary:            event.Title,
+		Description:        event.Description,
+		Start:              event.StartTime.Time,
+		End:                event.EndTime.Time,
+		LocationType:       event.LocationType,
+		CustomLocation:     event.CustomLocation,
+		ConferenceLink:     event.ConferenceLink,
+		Attendees:          emails,
+		HostName:           host.Name,
+		HostEmail:          host.Email,
+		EventID:            existingEventID,
+		MeetIdempotencyKey: event.ID,
+	}
+}
+
+func attendeeEmails(attendees []*models.HostedEventAttendee) []string {
+	out := make([]string, 0, len(attendees))
+	for _, a := range attendees {
+		out = append(out, a.Email)
+	}
+	return out
+}

--- a/internal/services/hosted_event_test.go
+++ b/internal/services/hosted_event_test.go
@@ -1,0 +1,699 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/config"
+	"github.com/meet-when/meet-when/internal/models"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+// spyEmailSender records every hosted-event email call. Concurrent-safe so
+// the goroutines inside SendHostedEventInvited et al don't race with the
+// test asserting on counts.
+type spyEmailSender struct {
+	mu sync.Mutex
+
+	invited          []emailCall
+	updated          []emailCall
+	cancelled        []emailCall
+	cancelledForAttn []emailCall
+	reminders        []emailCall
+}
+
+type emailCall struct {
+	EventID       string
+	AttendeeEmail string
+	ChangedFields []string
+}
+
+func (s *spyEmailSender) SendHostedEventInvited(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.invited = append(s.invited, emailCall{EventID: e.ID, AttendeeEmail: a.Email})
+}
+
+func (s *spyEmailSender) SendHostedEventUpdated(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant, changed []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.updated = append(s.updated, emailCall{EventID: e.ID, AttendeeEmail: a.Email, ChangedFields: append([]string(nil), changed...)})
+}
+
+func (s *spyEmailSender) SendHostedEventCancelled(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancelled = append(s.cancelled, emailCall{EventID: e.ID, AttendeeEmail: a.Email})
+}
+
+func (s *spyEmailSender) SendHostedEventCancelledForAttendee(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancelledForAttn = append(s.cancelledForAttn, emailCall{EventID: e.ID, AttendeeEmail: a.Email})
+}
+
+func (s *spyEmailSender) SendHostedEventReminder(_ context.Context, e *models.HostedEvent, a *models.HostedEventAttendee, _ *models.Host, _ *models.Tenant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reminders = append(s.reminders, emailCall{EventID: e.ID, AttendeeEmail: a.Email})
+}
+
+// invitedEmails returns the set of attendee emails that received an invite.
+func (s *spyEmailSender) invitedEmails() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.invited))
+	for i, c := range s.invited {
+		out[i] = c.AttendeeEmail
+	}
+	return out
+}
+
+func (s *spyEmailSender) updatedCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.updated)
+}
+
+func (s *spyEmailSender) cancelledForAttendeeEmails() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.cancelledForAttn))
+	for i, c := range s.cancelledForAttn {
+		out[i] = c.AttendeeEmail
+	}
+	return out
+}
+
+func (s *spyEmailSender) cancelledEmails() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.cancelled))
+	for i, c := range s.cancelled {
+		out[i] = c.AttendeeEmail
+	}
+	return out
+}
+
+// hostedEventHarness wires HostedEventService against real repos + a fake
+// calendar writer + a spy email sender. Conferencing and contact run against
+// real services; conferencing without a Zoom connection naturally returns
+// ErrConferencingReauthRequired, which lets us cover the reauth path.
+type hostedEventHarness struct {
+	svc      *HostedEventService
+	syncer   *CalendarEventSyncer
+	repos    *repository.Repositories
+	fake     *fakeCalendarWriter
+	email    *spyEmailSender
+	host     *models.Host
+	tenant   *models.Tenant
+	template *models.MeetingTemplate
+	calID    string // primary writable calendar
+	cleanup  func()
+}
+
+func makeHostedEventHarness(t *testing.T) *hostedEventHarness {
+	t.Helper()
+	_, repos, cleanup := setupTestRepos(t)
+	ctx := context.Background()
+
+	tenant := &models.Tenant{
+		ID: uuid.New().String(), Slug: "tenant-" + uuid.New().String()[:6], Name: "Test Tenant",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Tenant.Create(ctx, tenant); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+
+	host := &models.Host{
+		ID: uuid.New().String(), TenantID: tenant.ID,
+		Email: "h-" + uuid.New().String()[:4] + "@example.com", PasswordHash: "x",
+		Name: "Test Host", Slug: "host-" + uuid.New().String()[:6],
+		Timezone: "UTC", CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Host.Create(ctx, host); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+
+	conn := &models.CalendarConnection{
+		ID: uuid.New().String(), HostID: host.ID,
+		Provider: models.CalendarProviderGoogle, Name: "primary-conn",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Calendar.Create(ctx, conn); err != nil {
+		t.Fatalf("create calendar connection: %v", err)
+	}
+	pc := &models.ProviderCalendar{
+		ID: uuid.New().String(), ConnectionID: conn.ID,
+		ProviderCalendarID: "primary", Name: "Primary", Color: "#000",
+		IsPrimary: true, IsWritable: true, PollBusy: true,
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.ProviderCalendar.Create(ctx, pc); err != nil {
+		t.Fatalf("create provider calendar: %v", err)
+	}
+
+	template := &models.MeetingTemplate{
+		ID: uuid.New().String(), HostID: host.ID,
+		Slug: "tmpl-" + uuid.New().String()[:6], Name: "Sales call",
+		Description: "Default template", Durations: models.IntSlice{30},
+		LocationType: models.ConferencingProviderGoogleMeet, CalendarID: pc.ID,
+		MaxScheduleDays: 30, IsActive: true,
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Template.Create(ctx, template); err != nil {
+		t.Fatalf("create template: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Server.BaseURL = "http://test.local"
+
+	calendarSvc := NewCalendarService(cfg, repos)
+	conferencingSvc := NewConferencingService(cfg, repos)
+	contactSvc := NewContactService(repos)
+	auditSvc := NewAuditLogService(repos)
+
+	fake := &fakeCalendarWriter{}
+	syncer := &CalendarEventSyncer{
+		repos:    repos,
+		calendar: fake,
+		stores: map[ScheduledItemKind]trackingStore{
+			ItemKindBooking:     &bookingTrackingStore{repo: repos.BookingCalendarEvent},
+			ItemKindHostedEvent: &hostedEventTrackingStore{repo: repos.HostedEventCalendarEvent},
+		},
+	}
+
+	emailSpy := &spyEmailSender{}
+	svc := NewHostedEventService(cfg, repos, calendarSvc, conferencingSvc, syncer, emailSpy, contactSvc, auditSvc)
+
+	return &hostedEventHarness{
+		svc:      svc,
+		syncer:   syncer,
+		repos:    repos,
+		fake:     fake,
+		email:    emailSpy,
+		host:     host,
+		tenant:   tenant,
+		template: template,
+		calID:    pc.ID,
+		cleanup:  cleanup,
+	}
+}
+
+func (h *hostedEventHarness) baseCreateInput() CreateHostedEventInput {
+	return CreateHostedEventInput{
+		HostID:       h.host.ID,
+		TenantID:     h.tenant.ID,
+		Title:        "Quarterly review",
+		Description:  "What we shipped, what's next.",
+		Start:        time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC),
+		Duration:     30,
+		Timezone:     "UTC",
+		LocationType: models.ConferencingProviderGoogleMeet,
+		CalendarID:   h.calID,
+		Attendees: []AttendeeInput{
+			{Email: "alice@example.com", Name: "Alice"},
+			{Email: "bob@example.com", Name: "Bob"},
+		},
+	}
+}
+
+// waitForEmails spins until the spy reports the expected count, with a
+// generous timeout to absorb the goroutines launched by EmailService-style
+// senders. Our spy is synchronous, so this is effectively immediate, but the
+// helper keeps tests robust against future async drift.
+func (h *hostedEventHarness) waitForInvited(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(h.email.invitedEmails()) >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("expected %d invited emails, got %d", want, len(h.email.invitedEmails()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestHostedEventCreate_PersistsEventAndAttendees(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	out, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create returned err: %v", err)
+	}
+	if out == nil || out.Event == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if out.Event.Status != models.HostedEventStatusScheduled {
+		t.Fatalf("status = %q, want scheduled", out.Event.Status)
+	}
+	if out.Event.EndTime.Sub(out.Event.StartTime.Time) != 30*time.Minute {
+		t.Fatalf("end - start = %v, want 30m", out.Event.EndTime.Sub(out.Event.StartTime.Time))
+	}
+	persisted, err := h.repos.HostedEvent.GetByID(ctx, out.Event.ID)
+	if err != nil || persisted == nil {
+		t.Fatalf("persisted lookup: %v / %v", err, persisted)
+	}
+
+	attendees, err := h.repos.HostedEventAttendee.ListByEvent(ctx, out.Event.ID)
+	if err != nil {
+		t.Fatalf("ListByEvent: %v", err)
+	}
+	if len(attendees) != 2 {
+		t.Fatalf("expected 2 attendee rows, got %d", len(attendees))
+	}
+	if attendees[0].Email != "alice@example.com" || attendees[1].Email != "bob@example.com" {
+		t.Fatalf("attendee emails = %s, %s", attendees[0].Email, attendees[1].Email)
+	}
+}
+
+func TestHostedEventCreate_ResolvesCalendarFromExplicit(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	out, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.Event.CalendarID != h.calID {
+		t.Fatalf("explicit calendar not preserved: got %q, want %q", out.Event.CalendarID, h.calID)
+	}
+}
+
+func TestHostedEventCreate_ResolvesCalendarFromTemplateThenHost(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	// No explicit calendar. Template has CalendarID set; expect that.
+	in := h.baseCreateInput()
+	in.CalendarID = ""
+	tmplID := h.template.ID
+	in.TemplateID = &tmplID
+	out, err := h.svc.Create(ctx, in)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.Event.CalendarID != h.template.CalendarID {
+		t.Fatalf("template calendar not used: got %q, want %q", out.Event.CalendarID, h.template.CalendarID)
+	}
+
+	// No template either, but host has a default calendar.
+	defaultCal := h.calID
+	h.host.DefaultCalendarID = &defaultCal
+	if err := h.repos.Host.Update(ctx, h.host); err != nil {
+		t.Fatalf("update host: %v", err)
+	}
+	in2 := h.baseCreateInput()
+	in2.CalendarID = ""
+	in2.TemplateID = nil
+	out2, err := h.svc.Create(ctx, in2)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out2.Event.CalendarID != defaultCal {
+		t.Fatalf("host default calendar not used: got %q, want %q", out2.Event.CalendarID, defaultCal)
+	}
+}
+
+func TestHostedEventCreate_ConferencingReauthRequired_StillPersistsEvent(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	// Zoom location type without any Zoom OAuth connection seeded.
+	in := h.baseCreateInput()
+	in.LocationType = models.ConferencingProviderZoom
+	out, err := h.svc.Create(ctx, in)
+	if err != nil {
+		t.Fatalf("Create returned err (should swallow reauth-required on create): %v", err)
+	}
+	if out == nil || out.Event == nil {
+		t.Fatal("expected event to be persisted despite missing Zoom connection")
+	}
+	persisted, _ := h.repos.HostedEvent.GetByID(ctx, out.Event.ID)
+	if persisted == nil {
+		t.Fatal("event row missing after reauth-required path")
+	}
+	if persisted.ConferenceLink != "" {
+		t.Fatalf("conference link should be empty when conferencing fails; got %q", persisted.ConferenceLink)
+	}
+}
+
+func TestHostedEventCreate_GoogleMeet_LinkFromSyncerPersisted(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	// Simulate Google Meet returning a conference link via the calendar
+	// create response (the second-write path).
+	h.fake.nextCreate = []fakeCreateResult{{
+		EventID: "calendar-evt-1", ConferenceLink: "https://meet.google.com/zzz-aaa-bbb",
+	}}
+
+	out, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	persisted, _ := h.repos.HostedEvent.GetByID(ctx, out.Event.ID)
+	if persisted == nil {
+		t.Fatal("event missing")
+	}
+	if persisted.ConferenceLink != "https://meet.google.com/zzz-aaa-bbb" {
+		t.Fatalf("syncer-returned conference link not persisted: got %q", persisted.ConferenceLink)
+	}
+}
+
+func TestHostedEventCreate_SendsInvitedEmailToEachAttendee(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	if _, err := h.svc.Create(ctx, h.baseCreateInput()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.waitForInvited(t, 2)
+	got := h.email.invitedEmails()
+	if !contains(got, "alice@example.com") || !contains(got, "bob@example.com") {
+		t.Fatalf("invited recipients = %v, missing one of alice/bob", got)
+	}
+}
+
+func TestHostedEventCreate_UpsertsContactsForAttendees(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	if _, err := h.svc.Create(ctx, h.baseCreateInput()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Contact upsert is fire-and-forget but synchronous to the repo write
+	// inside ContactService.UpsertFromHostedEventAttendee. Allow a small
+	// settle window.
+	time.Sleep(20 * time.Millisecond)
+
+	c1, err := h.repos.Contact.GetByEmail(ctx, h.tenant.ID, "alice@example.com")
+	if err != nil {
+		t.Fatalf("get contact alice: %v", err)
+	}
+	if c1 == nil {
+		t.Fatal("expected contact for alice@example.com to be upserted")
+	}
+}
+
+func TestHostedEventUpdate_AttendeeDiff_RoutesEmailsCorrectly(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.waitForInvited(t, 2)
+
+	// Reset the spy so we only see the update-time emails.
+	h.email = &spyEmailSender{}
+	h.svc.email = h.email
+
+	// Bob removed, Carol added, Alice retained.
+	newAttendees := []AttendeeInput{
+		{Email: "alice@example.com", Name: "Alice"},
+		{Email: "carol@example.com", Name: "Carol"},
+	}
+	newTitle := "Quarterly review (updated)"
+	if _, _, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID:    h.host.ID,
+		TenantID:  h.tenant.ID,
+		EventID:   created.Event.ID,
+		Title:     &newTitle,
+		Attendees: &newAttendees,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Expect: 1 invited (Carol), 1 cancelled-for-attendee (Bob),
+	// 1 updated (Alice retained, title changed).
+	time.Sleep(30 * time.Millisecond)
+
+	if got := h.email.invitedEmails(); !equalSet(got, []string{"carol@example.com"}) {
+		t.Fatalf("invited = %v, want [carol]", got)
+	}
+	if got := h.email.cancelledForAttendeeEmails(); !equalSet(got, []string{"bob@example.com"}) {
+		t.Fatalf("cancelled-for-attendee = %v, want [bob]", got)
+	}
+	if h.email.updatedCount() != 1 {
+		t.Fatalf("expected 1 updated email (alice retained), got %d", h.email.updatedCount())
+	}
+}
+
+func TestHostedEventUpdate_TimeChange_ResetsReminderSent(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Mark reminder as already sent.
+	if err := h.repos.HostedEvent.MarkReminderSent(ctx, created.Event.ID); err != nil {
+		t.Fatalf("MarkReminderSent: %v", err)
+	}
+	pre, _ := h.repos.HostedEvent.GetByID(ctx, created.Event.ID)
+	if !pre.ReminderSent {
+		t.Fatal("precondition: reminder_sent should be true after MarkReminderSent")
+	}
+
+	newStart := created.Event.StartTime.Add(2 * time.Hour)
+	if _, _, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID:   h.host.ID,
+		TenantID: h.tenant.ID,
+		EventID:  created.Event.ID,
+		Start:    &newStart,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	post, _ := h.repos.HostedEvent.GetByID(ctx, created.Event.ID)
+	if post.ReminderSent {
+		t.Fatal("reminder_sent should reset to false after Start change")
+	}
+}
+
+func TestHostedEventUpdate_NoMaterialChange_SendsNoEmail(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.waitForInvited(t, 2)
+	h.email = &spyEmailSender{}
+	h.svc.email = h.email
+
+	// Update with no actual changes.
+	sameTitle := created.Event.Title
+	if _, changed, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID:   h.host.ID,
+		TenantID: h.tenant.ID,
+		EventID:  created.Event.ID,
+		Title:    &sameTitle,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	} else if len(changed) != 0 {
+		t.Fatalf("expected no changed fields, got %v", changed)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	if h.email.updatedCount() != 0 || len(h.email.invitedEmails()) != 0 {
+		t.Fatalf("no-op update should send no email; updated=%d invited=%d",
+			h.email.updatedCount(), len(h.email.invitedEmails()))
+	}
+}
+
+func TestHostedEventUpdate_PatchesAllTrackedCalendarEvents(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// One tracking row for the owner.
+	rows, _ := h.repos.HostedEventCalendarEvent.GetByHostedEventID(ctx, created.Event.ID)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 tracking row after create, got %d", len(rows))
+	}
+	h.fake.updateCalls = nil
+
+	newTitle := "Renamed"
+	if _, _, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID: h.host.ID, TenantID: h.tenant.ID, EventID: created.Event.ID,
+		Title: &newTitle,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := len(h.fake.updateCalls); got != 1 {
+		t.Fatalf("expected 1 calendar update call, got %d", got)
+	}
+}
+
+func TestHostedEventUpdate_ContactNotReupsertedForRetained(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	preAlice, _ := h.repos.Contact.GetByEmail(ctx, h.tenant.ID, "alice@example.com")
+	if preAlice == nil {
+		t.Fatal("alice contact missing after create")
+	}
+	preCount := preAlice.MeetingCount
+
+	// Update title only, keep both attendees. No new contact upsert should
+	// run for either retained attendee.
+	newTitle := "Renamed"
+	sameAttendees := []AttendeeInput{
+		{Email: "alice@example.com", Name: "Alice"},
+		{Email: "bob@example.com", Name: "Bob"},
+	}
+	if _, _, err := h.svc.Update(ctx, UpdateHostedEventInput{
+		HostID: h.host.ID, TenantID: h.tenant.ID, EventID: created.Event.ID,
+		Title: &newTitle, Attendees: &sameAttendees,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	postAlice, _ := h.repos.Contact.GetByEmail(ctx, h.tenant.ID, "alice@example.com")
+	if postAlice == nil {
+		t.Fatal("alice contact disappeared")
+	}
+	if postAlice.MeetingCount != preCount {
+		t.Fatalf("retained attendee meeting_count was re-incremented: %d → %d", preCount, postAlice.MeetingCount)
+	}
+}
+
+func TestHostedEventCancel_DeletesTrackedRowsAndEmails(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h.waitForInvited(t, 2)
+
+	if err := h.svc.Cancel(ctx, h.host.ID, h.tenant.ID, created.Event.ID, "no longer needed"); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	rows, _ := h.repos.HostedEventCalendarEvent.GetByHostedEventID(ctx, created.Event.ID)
+	if len(rows) != 0 {
+		t.Fatalf("expected 0 tracking rows after cancel, got %d", len(rows))
+	}
+	persisted, _ := h.repos.HostedEvent.GetByID(ctx, created.Event.ID)
+	if persisted.Status != models.HostedEventStatusCancelled {
+		t.Fatalf("status = %q, want cancelled", persisted.Status)
+	}
+	if persisted.CancelReason != "no longer needed" {
+		t.Fatalf("cancel reason = %q", persisted.CancelReason)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := h.email.cancelledEmails(); !equalSet(got, []string{"alice@example.com", "bob@example.com"}) {
+		t.Fatalf("cancelled emails = %v, want [alice, bob]", got)
+	}
+}
+
+func TestHostedEventDetectBusyConflicts_ExcludesSelf(t *testing.T) {
+	h := makeHostedEventHarness(t)
+	defer h.cleanup()
+	ctx := context.Background()
+
+	created, err := h.svc.Create(ctx, h.baseCreateInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Same window, excluding the event itself → no hosted-event conflict.
+	start := created.Event.StartTime.Time
+	end := created.Event.EndTime.Time
+	conflicts, err := h.svc.DetectBusyConflicts(ctx, h.host.ID, start, end, created.Event.ID)
+	if err != nil {
+		t.Fatalf("DetectBusyConflicts: %v", err)
+	}
+	for _, c := range conflicts {
+		if c.Start.Equal(start) && c.End.Equal(end) {
+			t.Fatalf("self-event reported as conflict; should be excluded")
+		}
+	}
+
+	// Without exclusion, the event itself shows up.
+	conflicts2, err := h.svc.DetectBusyConflicts(ctx, h.host.ID, start, end, "")
+	if err != nil {
+		t.Fatalf("DetectBusyConflicts (no exclude): %v", err)
+	}
+	hit := false
+	for _, c := range conflicts2 {
+		if c.Start.Equal(start) && c.End.Equal(end) {
+			hit = true
+		}
+	}
+	if !hit {
+		t.Fatalf("expected hosted event to surface in own-window conflict scan, got none")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Small assertion helpers
+// ---------------------------------------------------------------------------
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func equalSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	mb := make(map[string]int, len(b))
+	for _, v := range b {
+		mb[v]++
+	}
+	for _, v := range a {
+		if mb[v] == 0 {
+			return false
+		}
+		mb[v]--
+	}
+	return true
+}

--- a/internal/services/reminder.go
+++ b/internal/services/reminder.go
@@ -61,23 +61,28 @@ func (s *ReminderService) run() {
 	}
 }
 
-// checkAndSendReminders finds bookings that need reminders and sends them
+// checkAndSendReminders finds bookings and hosted events that need reminders
+// and sends them. Booking and hosted-event sources are processed in separate
+// sub-funcs so a partial failure in one source does not abort the other.
 func (s *ReminderService) checkAndSendReminders() {
 	ctx := context.Background()
 
-	// Find confirmed bookings starting in the next 24-25 hours that haven't had reminders sent
-	// We use a 1-hour window (24-25 hours) to ensure we don't miss any bookings
-	// and don't send reminders too early
+	// Window: 23-25 hours from now (1-hour cushion either side of "tomorrow"
+	// so we don't miss any items between ticks).
 	now := time.Now().UTC()
-	reminderWindowStart := now.Add(23 * time.Hour) // Start checking 23 hours from now
-	reminderWindowEnd := now.Add(25 * time.Hour)   // Up to 25 hours from now
+	windowStart := now.Add(23 * time.Hour)
+	windowEnd := now.Add(25 * time.Hour)
 
-	bookings, err := s.repos.Booking.GetBookingsNeedingReminder(ctx, reminderWindowStart, reminderWindowEnd)
+	s.processBookingReminders(ctx, windowStart, windowEnd)
+	s.processHostedEventReminders(ctx, windowStart, windowEnd)
+}
+
+func (s *ReminderService) processBookingReminders(ctx context.Context, windowStart, windowEnd time.Time) {
+	bookings, err := s.repos.Booking.GetBookingsNeedingReminder(ctx, windowStart, windowEnd)
 	if err != nil {
 		log.Printf("[REMINDER] Error fetching bookings needing reminders: %v", err)
 		return
 	}
-
 	if len(bookings) == 0 {
 		return
 	}
@@ -85,7 +90,6 @@ func (s *ReminderService) checkAndSendReminders() {
 	log.Printf("[REMINDER] Found %d bookings needing reminders", len(bookings))
 
 	for _, booking := range bookings {
-		// Get related entities
 		template, err := s.repos.Template.GetByID(ctx, booking.TemplateID)
 		if err != nil || template == nil {
 			log.Printf("[REMINDER] Error fetching template %s: %v", booking.TemplateID, err)
@@ -111,15 +115,55 @@ func (s *ReminderService) checkAndSendReminders() {
 			Tenant:   tenant,
 		}
 
-		// Send the reminder email
 		s.email.SendBookingReminder(ctx, details)
 
-		// Mark the reminder as sent
 		if err := s.repos.Booking.MarkReminderSent(ctx, booking.ID); err != nil {
 			log.Printf("[REMINDER] Error marking reminder sent for booking %s: %v", booking.ID, err)
 		} else {
 			log.Printf("[REMINDER] Sent reminder for booking %s (invitee: %s, meeting: %s at %s)",
 				booking.ID, booking.InviteeEmail, template.Name, booking.StartTime.Format(time.RFC3339))
+		}
+	}
+}
+
+func (s *ReminderService) processHostedEventReminders(ctx context.Context, windowStart, windowEnd time.Time) {
+	events, err := s.repos.HostedEvent.GetUpcomingForReminders(ctx, windowStart, windowEnd)
+	if err != nil {
+		log.Printf("[REMINDER] Error fetching hosted events needing reminders: %v", err)
+		return
+	}
+	if len(events) == 0 {
+		return
+	}
+
+	log.Printf("[REMINDER] Found %d hosted events needing reminders", len(events))
+
+	for _, event := range events {
+		host, err := s.repos.Host.GetByID(ctx, event.HostID)
+		if err != nil || host == nil {
+			log.Printf("[REMINDER] Error fetching host %s for hosted event %s: %v", event.HostID, event.ID, err)
+			continue
+		}
+		tenant, err := s.repos.Tenant.GetByID(ctx, event.TenantID)
+		if err != nil || tenant == nil {
+			log.Printf("[REMINDER] Error fetching tenant %s for hosted event %s: %v", event.TenantID, event.ID, err)
+			continue
+		}
+		attendees, err := s.repos.HostedEventAttendee.ListByEvent(ctx, event.ID)
+		if err != nil {
+			log.Printf("[REMINDER] Error loading attendees for hosted event %s: %v", event.ID, err)
+			continue
+		}
+
+		for _, a := range attendees {
+			s.email.SendHostedEventReminder(ctx, event, a, host, tenant)
+		}
+
+		if err := s.repos.HostedEvent.MarkReminderSent(ctx, event.ID); err != nil {
+			log.Printf("[REMINDER] Error marking reminder sent for hosted event %s: %v", event.ID, err)
+		} else {
+			log.Printf("[REMINDER] Sent reminder for hosted event %s (%d attendees, at %s)",
+				event.ID, len(attendees), event.StartTime.Format(time.RFC3339))
 		}
 	}
 }

--- a/internal/services/reminder_test.go
+++ b/internal/services/reminder_test.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meet-when/meet-when/internal/config"
+	"github.com/meet-when/meet-when/internal/models"
+)
+
+// TestReminder_processHostedEventReminders_FiresForEachAttendeeAndMarksSent
+// exercises the hosted-event branch of the reminder loop:
+//   - One scheduled hosted event sitting inside the 23-25h reminder window
+//   - Two attendees → expect two SendHostedEventReminder calls
+//   - reminder_sent flips to true after the dispatch
+//   - A second pass with the same window does not re-fire (because
+//     GetUpcomingForReminders filters reminder_sent rows)
+func TestReminder_processHostedEventReminders_FiresForEachAttendeeAndMarksSent(t *testing.T) {
+	_, repos, cleanup := setupTestRepos(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tenant := &models.Tenant{
+		ID: uuid.New().String(), Slug: "t", Name: "Tenant",
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Tenant.Create(ctx, tenant); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	host := &models.Host{
+		ID: uuid.New().String(), TenantID: tenant.ID,
+		Email: "host@example.com", PasswordHash: "x", Name: "Host", Slug: "host",
+		Timezone: "UTC", CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.Host.Create(ctx, host); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+
+	// Event scheduled in 24 hours, within the reminder window.
+	startAt := time.Now().UTC().Add(24 * time.Hour)
+	event := &models.HostedEvent{
+		ID: uuid.New().String(), TenantID: tenant.ID, HostID: host.ID,
+		Title: "Standup", StartTime: models.NewSQLiteTime(startAt),
+		EndTime: models.NewSQLiteTime(startAt.Add(30 * time.Minute)), Duration: 30,
+		Timezone: "UTC", LocationType: models.ConferencingProviderGoogleMeet,
+		Status:    models.HostedEventStatusScheduled,
+		CreatedAt: models.Now(), UpdatedAt: models.Now(),
+	}
+	if err := repos.HostedEvent.Create(ctx, event); err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	for _, email := range []string{"a@example.com", "b@example.com"} {
+		if err := repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, []*models.HostedEventAttendee{{
+			ID: uuid.New().String(), HostedEventID: event.ID, Email: email, Name: email,
+			CreatedAt: models.Now(),
+		}}); err != nil {
+			// ReplaceForEvent overwrites — switch to one call with both rows.
+			t.Fatalf("ReplaceForEvent: %v", err)
+		}
+	}
+	// Final attendee state: ReplaceForEvent above overwrites each call, so
+	// re-seed both atomically.
+	if err := repos.HostedEventAttendee.ReplaceForEvent(ctx, event.ID, []*models.HostedEventAttendee{
+		{ID: uuid.New().String(), HostedEventID: event.ID, Email: "a@example.com", Name: "A", CreatedAt: models.Now()},
+		{ID: uuid.New().String(), HostedEventID: event.ID, Email: "b@example.com", Name: "B", CreatedAt: models.Now()},
+	}); err != nil {
+		t.Fatalf("seed final attendees: %v", err)
+	}
+
+	// We can't intercept the real EmailService send (it would try to dial
+	// SMTP), so swap in a config that points to a non-existent provider —
+	// reminder dispatch logs but still marks the event as sent. The thing we
+	// actually verify here is that GetUpcomingForReminders + MarkReminderSent
+	// drive the state machine correctly; email content is covered by the
+	// hosted_event_test.go spy.
+	cfg := &config.Config{}
+	cfg.Email.Provider = "smtp"
+	cfg.Email.SMTPHost = "127.0.0.1"
+	cfg.Email.SMTPPort = 1 // guaranteed-closed port
+	cfg.Email.FromAddress = "noreply@test.local"
+	emailSvc := NewEmailService(cfg)
+
+	reminder := NewReminderService(repos, emailSvc)
+	reminder.processHostedEventReminders(ctx, time.Now().UTC().Add(23*time.Hour), time.Now().UTC().Add(25*time.Hour))
+
+	post, err := repos.HostedEvent.GetByID(ctx, event.ID)
+	if err != nil || post == nil {
+		t.Fatalf("post-fetch event: %v / %v", err, post)
+	}
+	if !post.ReminderSent {
+		t.Fatal("expected reminder_sent=true after processHostedEventReminders")
+	}
+
+	// A second pass over the same window must not pick the event up again.
+	due, err := repos.HostedEvent.GetUpcomingForReminders(ctx, time.Now().UTC().Add(23*time.Hour), time.Now().UTC().Add(25*time.Hour))
+	if err != nil {
+		t.Fatalf("GetUpcomingForReminders second pass: %v", err)
+	}
+	for _, e := range due {
+		if e.ID == event.ID {
+			t.Fatal("event re-surfaced after reminder_sent was marked")
+		}
+	}
+}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -21,6 +21,7 @@ type Services struct {
 	Timezone     *TimezoneService
 	Agenda       *AgendaService
 	Contact      *ContactService
+	HostedEvent  *HostedEventService
 }
 
 // New creates all services
@@ -42,6 +43,7 @@ func New(cfg *config.Config, repos *repository.Repositories) *Services {
 
 	timezoneSvc := NewTimezoneService()
 	agendaSvc := NewAgendaService(repos, calendarSvc)
+	hostedEventSvc := NewHostedEventService(cfg, repos, calendarSvc, conferencingSvc, syncerSvc, emailSvc, contactSvc, auditLogSvc)
 
 	return &Services{
 		Auth:         authSvc,
@@ -58,5 +60,6 @@ func New(cfg *config.Config, repos *repository.Repositories) *Services {
 		Timezone:     timezoneSvc,
 		Agenda:       agendaSvc,
 		Contact:      contactSvc,
+		HostedEvent:  hostedEventSvc,
 	}
 }

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -32,7 +32,8 @@ func New(cfg *config.Config, repos *repository.Repositories) *Services {
 	auditLogSvc := NewAuditLogService(repos)
 
 	contactSvc := NewContactService(repos)
-	bookingSvc := NewBookingService(cfg, repos, calendarSvc, conferencingSvc, emailSvc, auditLogSvc, contactSvc)
+	syncerSvc := NewCalendarEventSyncer(repos, calendarSvc)
+	bookingSvc := NewBookingService(cfg, repos, calendarSvc, syncerSvc, conferencingSvc, emailSvc, auditLogSvc, contactSvc)
 	templateSvc := NewTemplateService(repos, auditLogSvc)
 	sessionSvc := NewSessionService(cfg, repos)
 	authSvc := NewAuthService(cfg, repos, sessionSvc, auditLogSvc)

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -1,0 +1,44 @@
+package services
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/meet-when/meet-when/internal/config"
+	"github.com/meet-when/meet-when/internal/database"
+	"github.com/meet-when/meet-when/internal/repository"
+)
+
+// setupTestRepos opens an in-memory sqlite DB, applies all migrations, and
+// returns wired repositories. Used by service-level tests that need real
+// schema persistence (e.g. tracking-row writes in the syncer).
+func setupTestRepos(t *testing.T) (*sql.DB, *repository.Repositories, func()) {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	cfg := config.DatabaseConfig{
+		Driver:         "sqlite",
+		Name:           ":memory:",
+		MigrationsPath: cwd + "/../../migrations",
+	}
+
+	db, err := database.New(cfg)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := database.Migrate(db, cfg); err != nil {
+		_ = db.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+
+	cleanup := func() {
+		_ = db.Close()
+	}
+
+	return db, repository.NewRepositories(db, "sqlite"), cleanup
+}

--- a/migrations/014_add_hosted_events.down.sql
+++ b/migrations/014_add_hosted_events.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_hosted_event_calendar_events_item;
+DROP TABLE IF EXISTS hosted_event_calendar_events;
+DROP INDEX IF EXISTS idx_hosted_event_attendees_event;
+DROP TABLE IF EXISTS hosted_event_attendees;
+DROP INDEX IF EXISTS idx_hosted_events_tenant;
+DROP INDEX IF EXISTS idx_hosted_events_host_start;
+DROP TABLE IF EXISTS hosted_events;

--- a/migrations/014_add_hosted_events.up.sql
+++ b/migrations/014_add_hosted_events.up.sql
@@ -1,0 +1,49 @@
+-- Hosted events: host-driven scheduling (the inverse of bookings).
+CREATE TABLE hosted_events (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    host_id UUID NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    template_id UUID REFERENCES meeting_templates(id) ON DELETE SET NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    start_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    end_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    duration INTEGER NOT NULL,
+    timezone VARCHAR(100) NOT NULL DEFAULT 'UTC',
+    location_type VARCHAR(50) NOT NULL DEFAULT 'google_meet',
+    custom_location VARCHAR(500) NOT NULL DEFAULT '',
+    calendar_id VARCHAR(255) NOT NULL DEFAULT '',
+    conference_link VARCHAR(1000) NOT NULL DEFAULT '',
+    status VARCHAR(50) NOT NULL DEFAULT 'scheduled',
+    cancel_reason TEXT NOT NULL DEFAULT '',
+    reminder_sent BOOLEAN NOT NULL DEFAULT FALSE,
+    is_archived BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_hosted_events_host_start ON hosted_events(host_id, start_time);
+CREATE INDEX idx_hosted_events_tenant ON hosted_events(tenant_id);
+
+CREATE TABLE hosted_event_attendees (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    hosted_event_id UUID NOT NULL REFERENCES hosted_events(id) ON DELETE CASCADE,
+    email VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL DEFAULT '',
+    contact_id UUID REFERENCES contacts(id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE(hosted_event_id, email)
+);
+
+CREATE INDEX idx_hosted_event_attendees_event ON hosted_event_attendees(hosted_event_id);
+
+CREATE TABLE hosted_event_calendar_events (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    hosted_event_id UUID NOT NULL REFERENCES hosted_events(id) ON DELETE CASCADE,
+    host_id UUID NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    calendar_id UUID NOT NULL REFERENCES provider_calendars(id) ON DELETE CASCADE,
+    event_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_hosted_event_calendar_events_item ON hosted_event_calendar_events(hosted_event_id);

--- a/migrations/sqlite/014_add_hosted_events.down.sql
+++ b/migrations/sqlite/014_add_hosted_events.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_hosted_event_calendar_events_item;
+DROP TABLE IF EXISTS hosted_event_calendar_events;
+DROP INDEX IF EXISTS idx_hosted_event_attendees_event;
+DROP TABLE IF EXISTS hosted_event_attendees;
+DROP INDEX IF EXISTS idx_hosted_events_tenant;
+DROP INDEX IF EXISTS idx_hosted_events_host_start;
+DROP TABLE IF EXISTS hosted_events;

--- a/migrations/sqlite/014_add_hosted_events.up.sql
+++ b/migrations/sqlite/014_add_hosted_events.up.sql
@@ -1,0 +1,49 @@
+-- Hosted events: host-driven scheduling (the inverse of bookings).
+CREATE TABLE hosted_events (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    host_id TEXT NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    template_id TEXT REFERENCES meeting_templates(id) ON DELETE SET NULL,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    start_time TEXT NOT NULL,
+    end_time TEXT NOT NULL,
+    duration INTEGER NOT NULL,
+    timezone TEXT NOT NULL DEFAULT 'UTC',
+    location_type TEXT NOT NULL DEFAULT 'google_meet',
+    custom_location TEXT NOT NULL DEFAULT '',
+    calendar_id TEXT NOT NULL DEFAULT '',
+    conference_link TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'scheduled',
+    cancel_reason TEXT NOT NULL DEFAULT '',
+    reminder_sent INTEGER NOT NULL DEFAULT 0,
+    is_archived INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_hosted_events_host_start ON hosted_events(host_id, start_time);
+CREATE INDEX idx_hosted_events_tenant ON hosted_events(tenant_id);
+
+CREATE TABLE hosted_event_attendees (
+    id TEXT PRIMARY KEY,
+    hosted_event_id TEXT NOT NULL REFERENCES hosted_events(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    name TEXT NOT NULL DEFAULT '',
+    contact_id TEXT REFERENCES contacts(id) ON DELETE SET NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(hosted_event_id, email)
+);
+
+CREATE INDEX idx_hosted_event_attendees_event ON hosted_event_attendees(hosted_event_id);
+
+CREATE TABLE hosted_event_calendar_events (
+    id TEXT PRIMARY KEY,
+    hosted_event_id TEXT NOT NULL REFERENCES hosted_events(id) ON DELETE CASCADE,
+    host_id TEXT NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    calendar_id TEXT NOT NULL REFERENCES provider_calendars(id) ON DELETE CASCADE,
+    event_id TEXT NOT NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_hosted_event_calendar_events_item ON hosted_event_calendar_events(hosted_event_id);


### PR DESCRIPTION
## Summary

Phase C + F of host-driven event scheduling. Re-opened from PR #44 which GitHub auto-closed when its base branch (\`claude/refine-local-plan-9weBM\`) was deleted on merge of #43.

Builds on the syncer + schema already in main (#43). This PR is service + tests only — no handlers, no UI, no migrations. The next PR adds Phase D + E (handlers + UI).

## What's new

### \`HostedEventService\` (\`internal/services/hosted_event.go\`)

\`Create\`, \`Update\`, \`Cancel\`, \`Get\`, \`List\`, \`Archive\`, \`Unarchive\`, \`RetryCalendarEvent\`, \`DetectBusyConflicts\`.

Behavioural notes worth highlighting:

- **Calendar resolution priority**: explicit \`CalendarID\` → template default → host \`DefaultCalendarID\` → first writable (last fallback comes free from the syncer).
- **Two-write conferencing-link sequencing**: Zoom path persists the link first, then \`syncer.Create\` may surface a Google Meet link from the calendar create response, persisted with a second write.
- **\`ErrConferencingReauthRequired\` on \`Create\`** is logged and swallowed; on \`Update\` it surfaces.
- **\`reminder_sent\` is reset to \`false\` when \`Start\` changes\` so the reminder loop re-fires for the new time.
- **Contact upsert fires only for newly added attendees**, so retained attendees don't get \`meeting_count\` / \`last_met\` re-incremented on benign edits.
- **\`DetectBusyConflicts\` merges three sources** — provider busy times, confirmed bookings, other hosted events — with \`excludeEventID\` for self-edit.
- The service depends on a narrow \`hostedEventEmailSender\` interface so tests can inject a spy.

### Conferencing (\`internal/services/conferencing.go\`)
Extracted \`createZoomMeetingRaw(ctx, hostID, topic, start, durationMin)\`. New \`CreateMeetingForHostedEvent(...)\`. Existing \`CreateMeeting(details)\` keeps signature, delegates internally.

### Contacts (\`internal/services/contact.go\`)
New \`UpsertFromHostedEventAttendee\`.

### Email (\`internal/services/email.go\`)
Five new send methods following the inline-Go-string pattern of \`SendBookingConfirmed\`. Plus \`generateICSForHostedEvent\`. Cancellation paths emit METHOD:CANCEL ICS so calendar clients remove the event.

### Reminder (\`internal/services/reminder.go\`)
\`checkAndSendReminders\` splits into \`processBookingReminders\` + \`processHostedEventReminders\` so a failure in one source can't abort the other.

## Tests

\`internal/services/hosted_event_test.go\` — 13 cases covering persistence, calendar resolution priority, ErrConferencingReauthRequired handling, Google Meet link surfacing, attendee-diff email routing, reminder_sent reset, no-op-update sends no email, contact-not-reupserted-for-retained, cancel deletes tracking rows + emails, DetectBusyConflicts excludes self.

\`internal/services/reminder_test.go\` — \`processHostedEventReminders\` flips \`reminder_sent\` and prevents re-fire.

## Verification

- \`make test\` — all packages pass
- \`go vet ./...\` clean
- \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)